### PR TITLE
✨ Auth page

### DIFF
--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -1,18 +1,12 @@
-import Image from "next/image";
 import Link from "next/link";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <section className="px-4 py-20 flex flex-col items-center justify-center text-center">
       <Link href="/">
-        <Image
-          src="/assets/icons/logo.png"
-          alt="최애의 포토"
-          width={330}
-          height={60}
-          priority
-          className="w-[190px] h-[35px] md:w-[330px] md:h-[60px] mb-20"
-        />
+        <h1 className="font-BR-B text-5xl md:text-7xl mb-20">
+          최애<span className="text-main">의</span>포토
+        </h1>
       </Link>
       {children}
     </section>

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -1,0 +1,20 @@
+import Image from "next/image";
+import Link from "next/link";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <section className="px-4 py-20 flex flex-col items-center justify-center text-center">
+      <Link href="/">
+        <Image
+          src="/assets/icons/logo.png"
+          alt="최애의 포토"
+          width={330}
+          height={60}
+          priority
+          className="w-[190px] h-[35px] md:w-[330px] md:h-[60px] mb-20"
+        />
+      </Link>
+      {children}
+    </section>
+  );
+}

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,0 +1,11 @@
+import AuthLink from "@/components/auth/AuthLink";
+import LoginForm from "@/components/auth/LoginForm";
+
+export default function Page() {
+  return (
+    <>
+      <LoginForm />
+      <AuthLink type="signup" />
+    </>
+  );
+}

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -1,1 +1,11 @@
- 
+import AuthLink from "@/components/auth/AuthLink";
+import SignupForm from "@/components/auth/SignupForm";
+
+export default function Page() {
+  return (
+    <>
+      <SignupForm />
+      <AuthLink type="login" />
+    </>
+  );
+}

--- a/src/components/auth/AuthLink.tsx
+++ b/src/components/auth/AuthLink.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+interface AuthLinkProps {
+  type: "login" | "signup";
+}
+
+export default function AuthLink({ type }: AuthLinkProps) {
+  return (
+    <p className="font-normal text-sm xl:text-base flex gap-2">
+      {type === "signup" ? "최애의 포토가 처음이신가요?" : "이미 계정이 있으신가요?"}
+      <Link
+        href={type === "signup" ? "/auth/signup" : "/auth/login"}
+        className="text-main hover:underline"
+      >
+        {type === "signup" ? "회원가입하기" : "로그인하기"}
+      </Link>
+    </p>
+  );
+}

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -10,6 +10,7 @@ import { useActionState, useEffect } from "react";
 import loginAction from "@/lib/actions/login.action";
 import { useRouter } from "next/navigation";
 import useUserStore from "@/store/useUserStore";
+import { useSnackbarStore } from "@/store/useSnackbarStore";
 
 export default function LoginForm() {
   const {
@@ -25,7 +26,8 @@ export default function LoginForm() {
   });
   const [state, formAction, isPending] = useActionState(loginAction, null);
   const router = useRouter();
-  const { setUser } = useUserStore(); // ✅ Zustand 상태 업데이트 함수 가져오기
+  const { setUser } = useUserStore(); // 유저정보 상태 업데이트 함수 가져오기
+  const { openSnackbar } = useSnackbarStore(); // Snackbar 상태 업데이트 함수 가져오기
 
   useEffect(() => {
     if (!state) return; // 초기 state가 null인 경우 처리
@@ -38,9 +40,9 @@ export default function LoginForm() {
       // 완전히 새로고침 없이 페이지 이동이 되기 때문에 상태가 유지
     } else {
       // 로그인 실패시
-      alert(state.message); // 실패 메시지 출력
+      openSnackbar("ERROR", state.message); // Snackbar를 통해 에러 메시지 표시
     }
-  }, [state, router, setUser]);
+  }, [state, router, setUser, openSnackbar]);
 
   return (
     <form action={formAction} className="form-auth">

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { loginSchema, LoginFormSchema } from "@/schema/formSchema";
+import InputText from "@/components/common/input/Input";
+import Password from "@/components/common/input/Password";
+import ThinBtn from "../common/button/ThinBtn";
+import { useActionState, useEffect } from "react";
+import loginAction from "@/lib/actions/login.action";
+import { useRouter } from "next/navigation";
+import useUserStore from "@/store/useUserStore";
+
+export default function LoginForm() {
+  const {
+    control,
+    formState: { isValid },
+  } = useForm<LoginFormSchema>({
+    resolver: zodResolver(loginSchema),
+    mode: "onChange",
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+  });
+  const [state, formAction, isPending] = useActionState(loginAction, null);
+  const router = useRouter();
+  const { setUser } = useUserStore(); // ✅ Zustand 상태 업데이트 함수 가져오기
+
+  useEffect(() => {
+    if (!state) return; // 초기 state가 null인 경우 처리
+
+    if (state.status) {
+      // 로그인 성공시
+      setUser(state.user); // zustand store에 사용자 정보 저장
+      router.push("/"); // 로그인 성공 후 홈으로 이동,
+      // useRouter()가 클라이언트 내에서 상태를 유지한 채로 이동
+      // 완전히 새로고침 없이 페이지 이동이 되기 때문에 상태가 유지
+    } else {
+      // 로그인 실패시
+      alert(state.message); // 실패 메시지 출력
+    }
+  }, [state, router, setUser]);
+
+  return (
+    <form action={formAction} className="form-auth">
+      <InputText name="email" control={control} />
+      <Password name="password" control={control} />
+      <ThinBtn type="submit" disabled={!isValid || isPending} className="mt-[10px]">
+        {isPending ? "로그인 중..." : "로그인"}
+      </ThinBtn>
+    </form>
+  );
+}

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -9,6 +9,7 @@ import ThinBtn from "../common/button/ThinBtn";
 import signupAction from "@/lib/actions/signup.action";
 import { useActionState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useSnackbarStore } from "@/store/useSnackbarStore";
 
 export default function SignupForm() {
   const {
@@ -26,6 +27,7 @@ export default function SignupForm() {
   });
   const [state, formAction, isPending] = useActionState(signupAction, null);
   const router = useRouter();
+  const { openSnackbar } = useSnackbarStore(); // Snackbar 상태 업데이트 함수 가져오기
 
   useEffect(() => {
     if (!state) return; // 초기 state가 null인 경우 처리
@@ -38,9 +40,9 @@ export default function SignupForm() {
       // 완전히 새로고침 없이 페이지 이동이 되기 때문에 상태가 유지
     } else {
       // 회원가입 실패
-      alert(state.message); // 실패 메시지 출력
+      openSnackbar("ERROR", state.message); // Snackbar를 통해 에러 메시지 표시
     }
-  }, [state, router]);
+  }, [state, router, openSnackbar]);
 
   return (
     <form action={formAction} className="form-auth">

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -1,1 +1,56 @@
- 
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { SignupFormSchema, signupSchema } from "@/schema/formSchema";
+import InputText from "@/components/common/input/Input";
+import Password from "@/components/common/input/Password";
+import ThinBtn from "../common/button/ThinBtn";
+import signupAction from "@/lib/actions/signup.action";
+import { useActionState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export default function SignupForm() {
+  const {
+    control,
+    formState: { isValid, isSubmitting },
+  } = useForm<SignupFormSchema>({
+    resolver: zodResolver(signupSchema),
+    mode: "onChange",
+    defaultValues: {
+      email: "",
+      nickname: "",
+      password: "",
+      passwordConfirm: "",
+    },
+  });
+  const [state, formAction, isPending] = useActionState(signupAction, null);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!state) return; // 초기 state가 null인 경우 처리
+
+    if (state.status) {
+      // 회원가입 성공
+      alert(state.message);
+      router.push("/auth/login"); // 회원가입 성공 후 로그인 페이지로 이동
+      // useRouter()가 클라이언트 내에서 상태를 유지한 채로 이동
+      // 완전히 새로고침 없이 페이지 이동이 되기 때문에 상태가 유지
+    } else {
+      // 회원가입 실패
+      alert(state.message); // 실패 메시지 출력
+    }
+  }, [state, router]);
+
+  return (
+    <form action={formAction} className="form-auth">
+      <InputText name="email" control={control} />
+      <InputText name="nickname" control={control} />
+      <Password name="password" control={control} />
+      <Password name="passwordConfirm" control={control} />
+      <ThinBtn type="submit" disabled={!isValid || isSubmitting} className="mt-[10px]">
+        {isPending ? "가입 중..." : "가입하기"}
+      </ThinBtn>
+    </form>
+  );
+}

--- a/src/components/common/input/constants.ts
+++ b/src/components/common/input/constants.ts
@@ -5,7 +5,7 @@ export const FORM_CONFIG = {
       placeholder: "포토카드 이름을 입력해 주세요",
     },
     email: { label: "이메일", placeholder: "이메일을 입력해주세요" },
-    nick: { label: "닉네임", placeholder: "닉네임을 입력해주세요" },
+    nickname: { label: "닉네임", placeholder: "닉네임을 입력해주세요" },
     price: { label: "가격", placeholder: "가격을 입력해 주세요" },
     stock: { label: "총 발행량", placeholder: "총 발행량을 입력해 주세요" },
   },

--- a/src/lib/actions/login.action.ts
+++ b/src/lib/actions/login.action.ts
@@ -1,0 +1,38 @@
+"use server";
+
+import { axiosClient } from "@/services/axiosClient/axiosClient";
+import { AxiosError } from "axios";
+
+interface LoginProps {
+  email: string;
+  password: string;
+}
+
+export const login = async ({ email, password }: LoginProps) => {
+  try {
+    const response = await axiosClient.post("/auth/login", { email, password });
+    const { message, user } = response.data;
+    return { status: true, message, user };
+  } catch (error) {
+    const axiosError = error as AxiosError<{ error?: string }>;
+    const message = axiosError.response?.data?.error || "로그인 실패";
+    return { status: false, message, user: null };
+  }
+};
+
+export default async function loginAction(_: unknown, formData: FormData) {
+  const email = formData.get("email") as string;
+  const password = formData.get("password") as string;
+
+  if (!email || !password) {
+    return {
+      status: false,
+      message: "이메일과 비밀번호를 입력해주세요.",
+      user: null,
+    };
+  }
+
+  const result = await login({ email, password });
+
+  return result;
+}

--- a/src/lib/actions/signup.action.ts
+++ b/src/lib/actions/signup.action.ts
@@ -1,0 +1,39 @@
+"use server";
+
+import { axiosClient } from "@/services/axiosClient/axiosClient";
+import { AxiosError } from "axios";
+
+interface SignupProps {
+  email: string;
+  nickname: string;
+  password: string;
+}
+
+export const signup = async ({ email, password, nickname }: SignupProps) => {
+  try {
+    const response = await axiosClient.post("/auth/signup", { email, password, nickname });
+    const { message } = response.data;
+    return { status: true, message };
+  } catch (error) {
+    const axiosError = error as AxiosError<{ error?: string }>;
+    const message = axiosError.response?.data?.error || "회원가입 실패";
+    return { status: false, message };
+  }
+};
+
+export default async function signupAction(_: unknown, formData: FormData) {
+  const email = formData.get("email") as string;
+  const password = formData.get("password") as string;
+  const nickname = formData.get("nickname") as string;
+
+  if (!email || !password || !nickname) {
+    return {
+      status: false,
+      message: "이메일, 비밀번호, 닉네임을 입력해주세요.",
+    };
+  }
+
+  const result = await signup({ email, password, nickname });
+
+  return result;
+}

--- a/src/schema/formSchema.ts
+++ b/src/schema/formSchema.ts
@@ -1,0 +1,24 @@
+// form schema
+import { z } from "zod";
+import { InputSchema } from "@/schema/inputSchema";
+
+// 로그인 폼 스키마
+export const loginSchema = InputSchema.pick({
+  email: true,
+  password: true,
+});
+export type LoginFormSchema = z.infer<typeof loginSchema>; // 로그인 폼 스키마 타입
+
+// 회원가입 폼 스키마
+export const signupSchema = loginSchema
+  .merge(
+    InputSchema.pick({
+      nickname: true,
+      passwordConfirm: true,
+    })
+  )
+  .refine(data => data.password === data.passwordConfirm, {
+    message: "비밀번호가 일치하지 않습니다",
+    path: ["passwordConfirm"], // passwordConfirm 필드에서 오류 발생
+  });
+export type SignupFormSchema = z.infer<typeof signupSchema>;

--- a/src/schema/inputSchema.ts
+++ b/src/schema/inputSchema.ts
@@ -1,0 +1,36 @@
+// input schema
+import { z } from "zod";
+
+const notEmptySchema = z.string().min(1, ""); // 빈 문자열이 아닌지 확인
+const contentSchema = z
+  .string()
+  .min(10, "10자 이상 입력해주세요")
+  .max(100, "100자 이내로 입력해주세요"); // 설명은 10자 이상 100자 이내로 입력받음
+
+// 입력 폼 스키마
+export const InputSchema = z.object({
+  email: z.string().email("잘못된 이메일입니다"), // 이메일
+  nickname: z
+    .string()
+    .min(1, "닉네임을 입력해주세요") // 빈 값 방지
+    .max(6, "닉네임은 6자 이내로 입력해주세요"), // 닉네임
+  password: z
+    .string()
+    .min(9, "비밀번호를 9자 이상 입력해주세요") // 비밀번호 최소 길이
+    .regex(/[A-Z]/, "비밀번호에 대문자를 포함해주세요") // 대문자 포함
+    .regex(/[a-z]/, "비밀번호에 소문자를 포함해주세요") // 소문자 포함
+    .regex(/[0-9]/, "비밀번호에 숫자를 포함해주세요") // 숫자 포함
+    .regex(/[^A-Za-z0-9]/, "비밀번호에 특수기호를 포함해주세요"), // 특수기호 포함
+  passwordConfirm: z.string(), // 비밀번호 확인
+
+  photoCardName: z.string().max(30, "최대 30자 이내로 입력해주세요"), // 포토카드 이름
+  photoCardContent: contentSchema, // 포토카드 설명
+  image: z.string(), // 사진 url
+  price: z.number().int().positive("0보다 큰 수를 입력해주세요"), // 가격
+  stock: z.number().int().positive("0보다 큰 수를 입력해주세요"), // 총 발행량
+  search: z.string().min(1, "1자 이상 검색해주세요"), // 검색
+  wishContent: contentSchema, // 교환 희망 설명
+
+  genre: notEmptySchema, // 장르
+  grade: notEmptySchema, // 등급
+});

--- a/src/schema/inputSchema.ts
+++ b/src/schema/inputSchema.ts
@@ -12,8 +12,6 @@ const validatePassword = (password: string, ctx: z.RefinementCtx) => {
   const errors = [];
 
   if (password.length < 9) errors.push("9자 이상");
-  if (!/[A-Z]/.test(password)) errors.push("대문자 1개 이상");
-  if (!/[a-z]/.test(password)) errors.push("소문자 1개 이상");
   if (!/[0-9]/.test(password)) errors.push("숫자 1개 이상");
   if (!/[^A-Za-z0-9]/.test(password)) errors.push("특수기호 1개 이상");
 

--- a/src/schema/inputSchema.ts
+++ b/src/schema/inputSchema.ts
@@ -7,6 +7,24 @@ const contentSchema = z
   .min(10, "10자 이상 입력해주세요")
   .max(100, "100자 이내로 입력해주세요"); // 설명은 10자 이상 100자 이내로 입력받음
 
+const validatePassword = (password: string, ctx: z.RefinementCtx) => {
+  // 비밀번호 유효성 검사
+  const errors = [];
+
+  if (password.length < 9) errors.push("9자 이상");
+  if (!/[A-Z]/.test(password)) errors.push("대문자 1개 이상");
+  if (!/[a-z]/.test(password)) errors.push("소문자 1개 이상");
+  if (!/[0-9]/.test(password)) errors.push("숫자 1개 이상");
+  if (!/[^A-Za-z0-9]/.test(password)) errors.push("특수기호 1개 이상");
+
+  if (errors.length > 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `비밀번호는 ${errors.join(", ")}을 포함해야 합니다.`,
+    });
+  }
+};
+
 // 입력 폼 스키마
 export const InputSchema = z.object({
   email: z.string().email("잘못된 이메일입니다"), // 이메일
@@ -14,13 +32,7 @@ export const InputSchema = z.object({
     .string()
     .min(1, "닉네임을 입력해주세요") // 빈 값 방지
     .max(6, "닉네임은 6자 이내로 입력해주세요"), // 닉네임
-  password: z
-    .string()
-    .min(9, "비밀번호를 9자 이상 입력해주세요") // 비밀번호 최소 길이
-    .regex(/[A-Z]/, "비밀번호에 대문자를 포함해주세요") // 대문자 포함
-    .regex(/[a-z]/, "비밀번호에 소문자를 포함해주세요") // 소문자 포함
-    .regex(/[0-9]/, "비밀번호에 숫자를 포함해주세요") // 숫자 포함
-    .regex(/[^A-Za-z0-9]/, "비밀번호에 특수기호를 포함해주세요"), // 특수기호 포함
+  password: z.string().superRefine(validatePassword), // 비밀번호
   passwordConfirm: z.string(), // 비밀번호 확인
 
   photoCardName: z.string().max(30, "최대 30자 이내로 입력해주세요"), // 포토카드 이름

--- a/src/services/axiosClient/axiosClient.ts
+++ b/src/services/axiosClient/axiosClient.ts
@@ -4,7 +4,7 @@ import axios, { AxiosInstance, AxiosError, AxiosResponse } from "axios";
 const instances: Record<string, AxiosInstance> = {};
 
 // 개발 서버
-const devURL = "https://part2-db-dep.onrender.com";
+const devURL = "https://part2-db-dep.onrender.com/api";
 
 // 운영 서버
 // const prodURL = "https://#.onrender.com";

--- a/src/store/useUserStore.ts
+++ b/src/store/useUserStore.ts
@@ -1,0 +1,22 @@
+import { create } from "zustand";
+
+interface UserInfo {
+  id: string;
+  email: string;
+  nickname: string;
+}
+
+interface UserStore {
+  userInfo: UserInfo | null;
+  setUser: (user: UserInfo) => void;
+  clearUser: () => void;
+}
+
+// Zustand Store 생성
+const useUserStore = create<UserStore>(set => ({
+  userInfo: null, // 초기값: 로그인되지 않은 상태
+  setUser: userInfo => set({ userInfo }), // 사용자 정보 업데이트
+  clearUser: () => set({ userInfo: null }), // 로그아웃 시 초기화
+}));
+
+export default useUserStore;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -83,6 +83,11 @@
   .market-detail-subtitle {
     @apply text-[22px] lg:text-[28px] font-bold leading-none text-white;
   }
+
+  /* form - auth form style */
+  .form-auth {
+    @apply w-full max-w-110 md:w-110 xl:w-130 flex flex-col gap-[30px] mb-10;
+  }
 }
 
 :root {


### PR DESCRIPTION
login page & signup page

## 📌 개요

- #5 

## ✨ 주요 변경 사항

- Auth 페이지 UI & API 연동


## 📢 공유 사항(다른 팀원들도 알아두어야 할 것들)

- useUserStore에 userInfo 저장
- 비밀번호 zod 스키마 추가 (대소문자,숫자,특수기호 각각 1개씩 이상 사용하도록)

## 🖼️ 스크린샷

- 로그인 페이지
<img width="518" alt="스크린샷 2025-04-02 19 10 01" src="https://github.com/user-attachments/assets/0497e9f5-32c9-4f4d-b465-02bc1d3a3075" />

- 회원가입 페이지
<img width="501" alt="스크린샷 2025-04-02 19 10 15" src="https://github.com/user-attachments/assets/ad753311-1f24-4e5f-be01-5641cf47487e" />


