### PR TITLE
Fix/ 포토카드 관련 api 응답 - 장르 타입 수정 

### DIFF
--- a/src/app/market/[id]/page.tsx
+++ b/src/app/market/[id]/page.tsx
@@ -4,7 +4,9 @@
 // import { useParams } from 'next/navigation';
 import { SupplierPage } from "./SupplierPage";
 import { ConsumerPage } from "./ConsumerPage";
-import { Grade } from "@/types/photocard.types";
+import { Grade, Genre } from "@/types/photocard.types";
+
+// TODO: 등급/장르 포맷팅시키는 유틸함수 추가하기
 
 // XXX: 판매 카드 기본 상세 정보는 서버사이드 fetch,
 // XXX: 교환 목록은 reactQuery로 CSR 처리
@@ -20,7 +22,7 @@ export default function PhotoCardDetailPage() {
     imageUrl: "/assets/images/mock1.png",
     name: "우리집 앞마당",
     grade: "LEGENDARY" as Grade,
-    genre: "풍경",
+    genre: "LANDSCAPE" as Genre,
     description:
       "우리집 앞마당 포토카드입니다. 오랜만에 보니 너무 좋아요. 우리집 앞마당 포토카드입니다. 오랜만에 보니 너무 좋아요. 우리집 앞마당 포토카드입니다. 오랜만에 보니 너무 좋아요.",
     price: 4,
@@ -29,14 +31,15 @@ export default function PhotoCardDetailPage() {
     totalOwnAmount: 7,
     exchangeDetail: {
       grade: "RARE" as Grade,
-      genre: "인물",
+      genre: "PORTRAIT" as Genre,
       description: "푸릇푸릇한 여름 풍경, 눈 많이 내린 겨울 풍경 사진에 관심이 많습니다.",
     },
-    isMine: false,
+    isMine: true,
     createdAt: "2025-03-27",
   };
 
   const exchangeListData = {
+    saleCardId: "acg",
     isMine: false,
     // receivedOffers: null,
     receivedOffers: [
@@ -46,7 +49,7 @@ export default function PhotoCardDetailPage() {
         imageUrl: "/assets/images/mock3.png",
         name: "how far i'll go",
         grade: "SUPER_RARE" as Grade,
-        genre: "풍경",
+        genre: "LANDSCAPE" as Genre,
         description:
           "여름 바다 풍경과 교환하실래요? 여름 바다 풍경과 교환하실래요 여름 바다 풍경과 교환하실래요? 여름 바다 풍경과 교환하실래요 여름 바다 풍경과 교환하실래요? 여름 바다 풍경과 교환하실래요",
         price: 4,
@@ -58,7 +61,7 @@ export default function PhotoCardDetailPage() {
         imageUrl: "/assets/images/mock2.png",
         name: "스페인 여행",
         grade: "COMMON" as Grade,
-        genre: "인물",
+        genre: "PORTRAIT" as Genre,
         description: "스페인 여행 포토카드입니다. 오랜만에 보니 너무 좋아요.",
         price: 10,
         createdAt: "2025-03-27",
@@ -69,7 +72,7 @@ export default function PhotoCardDetailPage() {
         imageUrl: "/assets/images/mock3.png",
         name: "how far i'll go",
         grade: "SUPER_RARE" as Grade,
-        genre: "풍경",
+        genre: "LANDSCAPE" as Genre,
         description: "여름 바다 풍경과 교환하실래요? 여름 바다 풍경과 교환하실래요",
         price: 4,
         createdAt: "2025-03-27",
@@ -80,7 +83,7 @@ export default function PhotoCardDetailPage() {
         imageUrl: "/assets/images/mock2.png",
         name: "스페인 여행",
         grade: "COMMON" as Grade,
-        genre: "인물",
+        genre: "PORTRAIT" as Genre,
         description: "스페인 여행 포토카드입니다. 오랜만에 보니 너무 좋아요.",
         price: 10,
         createdAt: "2025-03-27",
@@ -91,7 +94,7 @@ export default function PhotoCardDetailPage() {
         imageUrl: "/assets/images/mock3.png",
         name: "how far i'll go",
         grade: "SUPER_RARE" as Grade,
-        genre: "풍경",
+        genre: "LANDSCAPE" as Genre,
         description: "여름 바다 풍경과 교환하실래요? 여름 바다 풍경과 교환하실래요",
         price: 4,
         createdAt: "2025-03-27",
@@ -102,7 +105,7 @@ export default function PhotoCardDetailPage() {
         imageUrl: "/assets/images/mock2.png",
         name: "스페인 여행",
         grade: "COMMON" as Grade,
-        genre: "인물",
+        genre: "PORTRAIT" as Genre,
         description: "스페인 여행 포토카드입니다. 오랜만에 보니 너무 좋아요.",
         price: 10,
         createdAt: "2025-03-27",
@@ -113,7 +116,7 @@ export default function PhotoCardDetailPage() {
         imageUrl: "/assets/images/mock3.png",
         name: "how far i'll go",
         grade: "SUPER_RARE" as Grade,
-        genre: "풍경",
+        genre: "LANDSCAPE" as Genre,
         description: "여름 바다 풍경과 교환하실래요? 여름 바다 풍경과 교환하실래요",
         price: 4,
         createdAt: "2025-03-27",
@@ -127,7 +130,7 @@ export default function PhotoCardDetailPage() {
         imageUrl: "/assets/images/mock3.png",
         name: "how far i'll go",
         grade: "SUPER_RARE" as Grade,
-        genre: "풍경",
+        genre: "LANDSCAPE" as Genre,
         description:
           "여름 바다 풍경과 교환하실래요? 여름 바다 풍경과 교환하실래요 여름 바다 풍경과 교환하실래요? 여름 바다 풍경과 교환하실래요 여름 바다 풍경과 교환하실래요? 여름 바다 풍경과 교환하실래요",
         price: 4,
@@ -139,7 +142,7 @@ export default function PhotoCardDetailPage() {
         imageUrl: "/assets/images/mock2.png",
         name: "스페인 여행",
         grade: "COMMON" as Grade,
-        genre: "인물",
+        genre: "PORTRAIT" as Genre,
         description: "스페인 여행 포토카드입니다. 오랜만에 보니 너무 좋아요.",
         price: 10,
         createdAt: "2025-03-27",
@@ -150,7 +153,7 @@ export default function PhotoCardDetailPage() {
         imageUrl: "/assets/images/mock3.png",
         name: "how far i'll go",
         grade: "SUPER_RARE" as Grade,
-        genre: "풍경",
+        genre: "LANDSCAPE" as Genre,
         description: "여름 바다 풍경과 교환하실래요? 여름 바다 풍경과 교환하실래요",
         price: 4,
         createdAt: "2025-03-27",

--- a/src/app/market/[id]/page.tsx
+++ b/src/app/market/[id]/page.tsx
@@ -6,8 +6,6 @@ import { SupplierPage } from "./SupplierPage";
 import { ConsumerPage } from "./ConsumerPage";
 import { Grade, Genre } from "@/types/photocard.types";
 
-// TODO: 등급/장르 포맷팅시키는 유틸함수 추가하기
-
 // XXX: 판매 카드 기본 상세 정보는 서버사이드 fetch,
 // XXX: 교환 목록은 reactQuery로 CSR 처리
 export default function PhotoCardDetailPage() {

--- a/src/app/my-photos/page.tsx
+++ b/src/app/my-photos/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Grade, MyPhotoCardDto } from "@/types/photocard.types";
+import { Grade, Genre, MyPhotoCardDto } from "@/types/photocard.types";
 import { CommonLayout } from "@/components/common/layout/CommonLayout";
 import HeaderSection from "@/components/my-page/HeaderSection";
 import MyPhotoCardGrades from "@/components/my-page/MyPhotoCardGrades";
@@ -18,7 +18,7 @@ const MyPhotos = () => {
     {
       id: "2",
       grade: "COMMON" as Grade,
-      genre: "풍경",
+      genre: "LANDSCAPE" as Genre,
       name: "우리집 앞마당",
       price: 4,
       availableAmount: 1,
@@ -29,7 +29,7 @@ const MyPhotos = () => {
     {
       id: "3",
       grade: "SUPER_RARE" as Grade,
-      genre: "풍경",
+      genre: "LANDSCAPE" as Genre,
       name: "How Far I'll Go",
       price: 4,
       availableAmount: 1,
@@ -40,7 +40,7 @@ const MyPhotos = () => {
     {
       id: "4",
       grade: "LEGENDARY" as Grade,
-      genre: "인물",
+      genre: "PORTRAIT" as Genre,
       name: "웃는 모습",
       price: 8,
       availableAmount: 1,
@@ -51,7 +51,7 @@ const MyPhotos = () => {
     {
       id: "5",
       grade: "COMMON" as Grade,
-      genre: "동물",
+      genre: "OBJECT" as Genre,
       name: "귀여운 강아지",
       price: 3,
       availableAmount: 2,
@@ -62,7 +62,7 @@ const MyPhotos = () => {
     {
       id: "6",
       grade: "RARE" as Grade,
-      genre: "음식",
+      genre: "FOOD" as Genre,
       name: "맛있는 파스타",
       price: 5,
       availableAmount: 1,
@@ -73,7 +73,7 @@ const MyPhotos = () => {
     {
       id: "7",
       grade: "SUPER_RARE" as Grade,
-      genre: "풍경",
+      genre: "LANDSCAPE" as Genre,
       name: "일몰",
       price: 7,
       availableAmount: 1,
@@ -84,7 +84,7 @@ const MyPhotos = () => {
     {
       id: "8",
       grade: "COMMON" as Grade,
-      genre: "인물",
+      genre: "PORTRAIT" as Genre,
       name: "친구들과 함께",
       price: 3,
       availableAmount: 3,
@@ -95,7 +95,7 @@ const MyPhotos = () => {
     {
       id: "9",
       grade: "LEGENDARY" as Grade,
-      genre: "풍경",
+      genre: "LANDSCAPE" as Genre,
       name: "오로라",
       price: 10,
       availableAmount: 1,
@@ -106,7 +106,7 @@ const MyPhotos = () => {
     {
       id: "10",
       grade: "RARE" as Grade,
-      genre: "동물",
+      genre: "OBJECT" as Genre,
       name: "잠자는 고양이",
       price: 5,
       availableAmount: 2,
@@ -117,7 +117,7 @@ const MyPhotos = () => {
     {
       id: "11",
       grade: "SUPER_RARE" as Grade,
-      genre: "음식",
+      genre: "FOOD" as Genre,
       name: "홈메이드 케이크",
       price: 6,
       availableAmount: 1,
@@ -128,7 +128,7 @@ const MyPhotos = () => {
     {
       id: "12",
       grade: "COMMON" as Grade,
-      genre: "풍경",
+      genre: "LANDSCAPE" as Genre,
       name: "도시야경",
       price: 4,
       availableAmount: 2,
@@ -139,7 +139,7 @@ const MyPhotos = () => {
     {
       id: "13",
       grade: "LEGENDARY" as Grade,
-      genre: "인물",
+      genre: "PORTRAIT" as Genre,
       name: "공연현장",
       price: 9,
       availableAmount: 1,
@@ -150,7 +150,7 @@ const MyPhotos = () => {
     {
       id: "14",
       grade: "RARE" as Grade,
-      genre: "동물",
+      genre: "OBJECT" as Genre,
       name: "새들의 군무",
       price: 6,
       availableAmount: 1,
@@ -161,7 +161,7 @@ const MyPhotos = () => {
     {
       id: "15",
       grade: "SUPER_RARE" as Grade,
-      genre: "음식",
+      genre: "FOOD" as Genre,
       name: "디저트 플레이팅",
       price: 7,
       availableAmount: 1,
@@ -172,7 +172,7 @@ const MyPhotos = () => {
     {
       id: "16",
       grade: "COMMON" as Grade,
-      genre: "풍경",
+      genre: "LANDSCAPE" as Genre,
       name: "산정상",
       price: 3,
       availableAmount: 2,
@@ -183,7 +183,7 @@ const MyPhotos = () => {
     {
       id: "17",
       grade: "LEGENDARY" as Grade,
-      genre: "인물",
+      genre: "PORTRAIT" as Genre,
       name: "졸업식",
       price: 8,
       availableAmount: 1,
@@ -194,7 +194,7 @@ const MyPhotos = () => {
     {
       id: "18",
       grade: "RARE" as Grade,
-      genre: "동물",
+      genre: "OBJECT" as Genre,
       name: "수족관",
       price: 5,
       availableAmount: 1,

--- a/src/app/my-photos/page.tsx
+++ b/src/app/my-photos/page.tsx
@@ -62,7 +62,7 @@ const MyPhotos = () => {
     {
       id: "6",
       grade: "RARE" as Grade,
-      genre: "FOOD" as Genre,
+      genre: "OBJECT" as Genre,
       name: "맛있는 파스타",
       price: 5,
       availableAmount: 1,
@@ -117,7 +117,7 @@ const MyPhotos = () => {
     {
       id: "11",
       grade: "SUPER_RARE" as Grade,
-      genre: "FOOD" as Genre,
+      genre: "OBJECT" as Genre,
       name: "홈메이드 케이크",
       price: 6,
       availableAmount: 1,
@@ -161,7 +161,7 @@ const MyPhotos = () => {
     {
       id: "15",
       grade: "SUPER_RARE" as Grade,
-      genre: "FOOD" as Genre,
+      genre: "OBJECT" as Genre,
       name: "디저트 플레이팅",
       price: 7,
       availableAmount: 1,

--- a/src/app/my-sales/page.tsx
+++ b/src/app/my-sales/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Grade, MyPhotoCardDto } from "@/types/photocard.types";
+import { Genre, Grade, MyPhotoCardDto } from "@/types/photocard.types";
 import { CommonLayout } from "@/components/common/layout/CommonLayout";
 import HeaderSection from "@/components/my-page/HeaderSection";
 import MyPhotoCardGrades from "@/components/my-page/MyPhotoCardGrades";
@@ -25,7 +25,7 @@ const MySales = () => {
     {
       id: "2",
       grade: "COMMON" as Grade,
-      genre: "풍경",
+      genre: "LANDSCAPE" as Genre,
       name: "우리집 앞마당",
       price: 4,
       availableAmount: 1,
@@ -37,7 +37,7 @@ const MySales = () => {
     {
       id: "3",
       grade: "SUPER_RARE" as Grade,
-      genre: "풍경",
+      genre: "LANDSCAPE" as Genre,
       name: "How Far I'll Go",
       price: 4,
       availableAmount: 1,
@@ -49,7 +49,7 @@ const MySales = () => {
     {
       id: "4",
       grade: "LEGENDARY" as Grade,
-      genre: "인물",
+      genre: "PORTRAIT" as Genre,
       name: "웃는 모습",
       price: 8,
       availableAmount: 1,
@@ -61,7 +61,7 @@ const MySales = () => {
     {
       id: "5",
       grade: "COMMON" as Grade,
-      genre: "동물",
+      genre: "OBJECT" as Genre,
       name: "귀여운 강아지",
       price: 3,
       availableAmount: 2,
@@ -73,7 +73,7 @@ const MySales = () => {
     {
       id: "6",
       grade: "RARE" as Grade,
-      genre: "음식",
+      genre: "OBJECT" as Genre,
       name: "맛있는 파스타",
       price: 5,
       availableAmount: 1,
@@ -85,7 +85,7 @@ const MySales = () => {
     {
       id: "7",
       grade: "SUPER_RARE" as Grade,
-      genre: "풍경",
+      genre: "LANDSCAPE" as Genre,
       name: "일몰",
       price: 7,
       availableAmount: 1,
@@ -97,7 +97,7 @@ const MySales = () => {
     {
       id: "8",
       grade: "COMMON" as Grade,
-      genre: "인물",
+      genre: "PORTRAIT" as Genre,
       name: "친구들과 함께",
       price: 3,
       availableAmount: 3,
@@ -109,7 +109,7 @@ const MySales = () => {
     {
       id: "9",
       grade: "LEGENDARY" as Grade,
-      genre: "풍경",
+      genre: "LANDSCAPE" as Genre,
       name: "오로라",
       price: 10,
       availableAmount: 1,
@@ -121,7 +121,7 @@ const MySales = () => {
     {
       id: "10",
       grade: "RARE" as Grade,
-      genre: "동물",
+      genre: "OBJECT" as Genre,
       name: "잠자는 고양이",
       price: 5,
       availableAmount: 2,
@@ -133,7 +133,7 @@ const MySales = () => {
     {
       id: "11",
       grade: "SUPER_RARE" as Grade,
-      genre: "음식",
+      genre: "OBJECT" as Genre,
       name: "홈메이드 케이크",
       price: 6,
       availableAmount: 1,
@@ -145,7 +145,7 @@ const MySales = () => {
     {
       id: "12",
       grade: "COMMON" as Grade,
-      genre: "풍경",
+      genre: "LANDSCAPE" as Genre,
       name: "도시야경",
       price: 4,
       availableAmount: 2,
@@ -157,7 +157,7 @@ const MySales = () => {
     {
       id: "13",
       grade: "LEGENDARY" as Grade,
-      genre: "인물",
+      genre: "PORTRAIT" as Genre,
       name: "공연현장",
       price: 9,
       availableAmount: 1,
@@ -169,7 +169,7 @@ const MySales = () => {
     {
       id: "14",
       grade: "RARE" as Grade,
-      genre: "동물",
+      genre: "OBJECT" as Genre,
       name: "새들의 군무",
       price: 6,
       availableAmount: 1,
@@ -181,7 +181,7 @@ const MySales = () => {
     {
       id: "15",
       grade: "SUPER_RARE" as Grade,
-      genre: "음식",
+      genre: "OBJECT" as Genre,
       name: "디저트 플레이팅",
       price: 7,
       availableAmount: 1,
@@ -193,7 +193,7 @@ const MySales = () => {
     {
       id: "16",
       grade: "COMMON" as Grade,
-      genre: "풍경",
+      genre: "LANDSCAPE" as Genre,
       name: "산정상",
       price: 3,
       availableAmount: 2,
@@ -205,7 +205,7 @@ const MySales = () => {
     {
       id: "17",
       grade: "LEGENDARY" as Grade,
-      genre: "인물",
+      genre: "PORTRAIT" as Genre,
       name: "졸업식",
       price: 8,
       availableAmount: 1,
@@ -217,7 +217,7 @@ const MySales = () => {
     {
       id: "18",
       grade: "RARE" as Grade,
-      genre: "동물",
+      genre: "OBJECT" as Genre,
       name: "수족관",
       price: 5,
       availableAmount: 1,

--- a/src/components/common/card/CardHeader.tsx
+++ b/src/components/common/card/CardHeader.tsx
@@ -1,9 +1,9 @@
-import { CardType, Grade } from "@/types/photocard.types";
+import { CardType, Grade, Genre } from "@/types/photocard.types";
 import clsx from "clsx";
 
 interface CardHeaderProps {
   grade: Grade;
-  genre: string;
+  genre: Genre;
   points?: number;
   creator?: string;
   cardType: CardType;
@@ -16,8 +16,19 @@ const gradeColor = {
   LEGENDARY: "text-red",
 };
 
+const genreDisplayMap: Record<Genre, string> = {
+  TRAVEL: "여행",
+  LANDSCAPE: "풍경",
+  PORTRAIT: "인물",
+  OBJECT: "사물",
+};
+
 const formatGradeDisplay = (grade: Grade): string => {
   return grade.replace("_", " ");
+};
+
+const formatGenreDisplay = (genre: Genre): string => {
+  return genreDisplayMap[genre];
 };
 
 const CardHeader = ({ ...props }: CardHeaderProps) => {
@@ -42,7 +53,7 @@ const CardHeader = ({ ...props }: CardHeaderProps) => {
             {formatGradeDisplay(props.grade)}
           </div>
           <div className={`${verticalLineStyle}`}></div>
-          <div className="inline-block leading-none">{props.genre}</div>
+          <div className="inline-block leading-none">{formatGenreDisplay(props.genre)}</div>
         </div>
         {props.points && (
           <div className="flex items-center gap-[10px] lg:gap-4">

--- a/src/components/common/input/CommonDropdownInput.tsx
+++ b/src/components/common/input/CommonDropdownInput.tsx
@@ -1,37 +1,47 @@
 "use client";
 
 import { useState } from "react";
-import { Grade } from "@/types/photocard.types";
+import { Grade, Genre } from "@/types/photocard.types";
 import Image from "next/image";
 
 type DropdownType = {
   grade: {
     label: string;
     placeholder: string;
-    options: Grade[];
+    options: Record<Grade, string>;
     value: Grade;
   };
   genre: {
     label: string;
     placeholder: string;
-    options: string[];
-    value: string;
+    options: Record<Genre, string>;
+    value: Genre;
   };
 };
 
-// TODO: 등급 포맷팅 필요
-const dropdownOptions: DropdownType = {
+const dropdownOptions: Record<
+  keyof DropdownType,
+  Omit<DropdownType[keyof DropdownType], "value">
+> = {
   grade: {
     label: "등급",
     placeholder: "등급을 선택해 주세요",
-    options: ["COMMON", "RARE", "SUPER_RARE", "LEGENDARY"],
-    value: "" as Grade,
+    options: {
+      COMMON: "COMMON",
+      RARE: "RARE",
+      SUPER_RARE: "SUPER RARE",
+      LEGENDARY: "LEGENDARY",
+    },
   },
   genre: {
     label: "장르",
     placeholder: "장르를 선택해 주세요",
-    options: ["여행", "풍경", "인물", "사물"],
-    value: "",
+    options: {
+      TRAVEL: "여행",
+      LANDSCAPE: "풍경",
+      PORTRAIT: "인물",
+      OBJECT: "사물",
+    },
   },
 };
 
@@ -49,25 +59,27 @@ export default function CommonDropdownInput<T extends keyof DropdownType>({
   const [isOpen, setIsOpen] = useState(false);
   const { label, placeholder, options } = dropdownOptions[inputLabel];
 
-  // 현재 선택된 값 표시
-  const selectedValue = value || "";
+  const handleOptionClick = (key: string, event: React.MouseEvent) => {
+    event.stopPropagation();
+    onChange(key as DropdownType[T]["value"]);
+    setIsOpen(false);
+  };
+
+  const selectedText = value ? options[value as keyof typeof options] : "";
 
   return (
     <div className="flex flex-col w-full">
-      <label
-        htmlFor={inputLabel}
-        className="text-white font-bold text-[16px] lg:text-[20px] mb-3 text-left"
-      >
+      <label className="text-white font-bold text-[16px] lg:text-[20px] mb-3 text-left">
         {label}
       </label>
 
       <div className="relative" onClick={() => setIsOpen(prev => !prev)}>
         <input
           type="text"
-          value={selectedValue}
+          value={selectedText}
           className={`rounded-[2px] p-3 font-light text-base w-full outline-none border-[1px] border-gray-200 cursor-pointer text-white
             ${isOpen ? "outline-main" : ""}
-            ${!selectedValue ? "placeholder:text-gray-200 placeholder:font-light" : ""}`}
+            ${!value ? "placeholder:text-gray-200 placeholder:font-light" : ""}`}
           placeholder={placeholder}
           readOnly
         />
@@ -82,18 +94,14 @@ export default function CommonDropdownInput<T extends keyof DropdownType>({
         />
         {isOpen && (
           <ul className="bg-dark w-full border border-gray-200 rounded-[2px] p-[10px] mt-1 z-10 absolute">
-            {options.map(option => (
+            {Object.entries(options).map(([key, text]) => (
               <li
-                key={option}
+                key={key}
                 className={`p-3 cursor-pointer hover:bg-main hover:rounded-[2px] hover:text-dark
-                  ${option === selectedValue ? "text-main" : "text-white"}`}
-                onClick={event => {
-                  event.stopPropagation();
-                  onChange(option as DropdownType[T]["value"]);
-                  setIsOpen(false);
-                }}
+                  ${key === value ? "text-main" : "text-white"}`}
+                onClick={e => handleOptionClick(key, e)}
               >
-                {option}
+                {text}
               </li>
             ))}
           </ul>

--- a/src/components/common/responsiveLayout/responsiveMyPhotoList/MyPhotoListContent.tsx
+++ b/src/components/common/responsiveLayout/responsiveMyPhotoList/MyPhotoListContent.tsx
@@ -1,5 +1,5 @@
 import { GradeFilter, GenreFilter } from "@/types/filter.types";
-import { Grade, MyPhotoCardDto } from "@/types/photocard.types";
+import { Genre, Grade, MyPhotoCardDto } from "@/types/photocard.types";
 import { FILTER_CONFIG } from "../../filter/constants";
 import { useEffect, useState } from "react";
 import FilterSection from "@/components/my-page/my-photo/FilterSection";
@@ -125,7 +125,7 @@ const myPhotoCards: MyPhotoCardDto[] = [
   {
     id: "2",
     grade: "COMMON" as Grade,
-    genre: "풍경",
+    genre: "LANDSCAPE" as Genre,
     name: "우리집 앞마당",
     price: 4,
     availableAmount: 1,
@@ -136,7 +136,7 @@ const myPhotoCards: MyPhotoCardDto[] = [
   {
     id: "3",
     grade: "SUPER_RARE" as Grade,
-    genre: "풍경",
+    genre: "LANDSCAPE" as Genre,
     name: "How Far I'll Go",
     price: 4,
     availableAmount: 1,
@@ -147,7 +147,7 @@ const myPhotoCards: MyPhotoCardDto[] = [
   {
     id: "4",
     grade: "LEGENDARY" as Grade,
-    genre: "인물",
+    genre: "PORTRAIT" as Genre,
     name: "웃는 모습",
     price: 8,
     availableAmount: 1,
@@ -158,7 +158,7 @@ const myPhotoCards: MyPhotoCardDto[] = [
   {
     id: "5",
     grade: "COMMON" as Grade,
-    genre: "동물",
+    genre: "OBJECT" as Genre,
     name: "귀여운 강아지",
     price: 3,
     availableAmount: 2,
@@ -169,7 +169,7 @@ const myPhotoCards: MyPhotoCardDto[] = [
   {
     id: "6",
     grade: "RARE" as Grade,
-    genre: "음식",
+    genre: "OBJECT" as Genre,
     name: "맛있는 파스타",
     price: 5,
     availableAmount: 1,
@@ -180,7 +180,7 @@ const myPhotoCards: MyPhotoCardDto[] = [
   {
     id: "7",
     grade: "SUPER_RARE" as Grade,
-    genre: "풍경",
+    genre: "LANDSCAPE" as Genre,
     name: "일몰",
     price: 7,
     availableAmount: 1,
@@ -191,7 +191,7 @@ const myPhotoCards: MyPhotoCardDto[] = [
   {
     id: "8",
     grade: "COMMON" as Grade,
-    genre: "인물",
+    genre: "PORTRAIT" as Genre,
     name: "친구들과 함께",
     price: 3,
     availableAmount: 3,
@@ -202,7 +202,7 @@ const myPhotoCards: MyPhotoCardDto[] = [
   {
     id: "9",
     grade: "LEGENDARY" as Grade,
-    genre: "풍경",
+    genre: "LANDSCAPE" as Genre,
     name: "오로라",
     price: 10,
     availableAmount: 1,
@@ -213,7 +213,7 @@ const myPhotoCards: MyPhotoCardDto[] = [
   {
     id: "10",
     grade: "RARE" as Grade,
-    genre: "동물",
+    genre: "OBJECT" as Genre,
     name: "잠자는 고양이",
     price: 5,
     availableAmount: 2,
@@ -224,7 +224,7 @@ const myPhotoCards: MyPhotoCardDto[] = [
   {
     id: "11",
     grade: "SUPER_RARE" as Grade,
-    genre: "음식",
+    genre: "OBJECT" as Genre,
     name: "홈메이드 케이크",
     price: 6,
     availableAmount: 1,
@@ -235,7 +235,7 @@ const myPhotoCards: MyPhotoCardDto[] = [
   {
     id: "12",
     grade: "COMMON" as Grade,
-    genre: "풍경",
+    genre: "LANDSCAPE" as Genre,
     name: "도시야경",
     price: 4,
     availableAmount: 2,
@@ -246,7 +246,7 @@ const myPhotoCards: MyPhotoCardDto[] = [
   {
     id: "13",
     grade: "LEGENDARY" as Grade,
-    genre: "인물",
+    genre: "PORTRAIT" as Genre,
     name: "공연현장",
     price: 9,
     availableAmount: 1,
@@ -257,7 +257,7 @@ const myPhotoCards: MyPhotoCardDto[] = [
   {
     id: "14",
     grade: "RARE" as Grade,
-    genre: "동물",
+    genre: "OBJECT" as Genre,
     name: "새들의 군무",
     price: 6,
     availableAmount: 1,
@@ -268,7 +268,7 @@ const myPhotoCards: MyPhotoCardDto[] = [
   {
     id: "15",
     grade: "SUPER_RARE" as Grade,
-    genre: "음식",
+    genre: "OBJECT" as Genre,
     name: "디저트 플레이팅",
     price: 7,
     availableAmount: 1,
@@ -279,7 +279,7 @@ const myPhotoCards: MyPhotoCardDto[] = [
   {
     id: "16",
     grade: "COMMON" as Grade,
-    genre: "풍경",
+    genre: "LANDSCAPE" as Genre,
     name: "산정상",
     price: 3,
     availableAmount: 2,
@@ -290,7 +290,7 @@ const myPhotoCards: MyPhotoCardDto[] = [
   {
     id: "17",
     grade: "LEGENDARY" as Grade,
-    genre: "인물",
+    genre: "PORTRAIT" as Genre,
     name: "졸업식",
     price: 8,
     availableAmount: 1,
@@ -301,7 +301,7 @@ const myPhotoCards: MyPhotoCardDto[] = [
   {
     id: "18",
     grade: "RARE" as Grade,
-    genre: "동물",
+    genre: "OBJECT" as Genre,
     name: "수족관",
     price: 5,
     availableAmount: 1,

--- a/src/components/market/detail/consumer/ExchangeDetail.tsx
+++ b/src/components/market/detail/consumer/ExchangeDetail.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { SectionTitle } from "../SectionTitle";
 import ThinBtn from "@/components/common/button/ThinBtn";
-import { CardType, Grade, MyPhotoCardDto } from "@/types/photocard.types";
+import { CardType, Grade, Genre, MyPhotoCardDto } from "@/types/photocard.types";
 import CardHeader from "@/components/common/card/CardHeader";
 import ResponsiveMyPhotoList from "@/components/common/responsiveLayout/responsiveMyPhotoList/ResponsiveMyPhotoList";
 import { ExchangeOfferInputForm } from "./ExchangeOfferInputForm";
@@ -10,7 +10,7 @@ import ResponsiveForm from "@/components/common/responsiveLayout/responsiveForm/
 interface ExchangeDetailProps {
   exchangeDetail: {
     grade: Grade;
-    genre: string;
+    genre: Genre;
     description: string;
   };
 }

--- a/src/hooks/market/detail/useEditSaleCardForm.tsx
+++ b/src/hooks/market/detail/useEditSaleCardForm.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useState } from "react";
 // import { useQueryClient } from '@tanstack/react-query';
-import { Grade, SaleCardDetailDto, UpdateSaleCardBodyParams } from "@/types/photocard.types";
+import { Grade, Genre, SaleCardDetailDto, UpdateSaleCardBodyParams } from "@/types/photocard.types";
 import { useSnackbarStore } from "@/store/useSnackbarStore";
 
 export const useEditSaleCardForm = (initialData: SaleCardDetailDto, onClose: () => void) => {
@@ -23,7 +23,7 @@ export const useEditSaleCardForm = (initialData: SaleCardDetailDto, onClose: () 
   const updateParams = useCallback(
     (
       field: keyof UpdateSaleCardBodyParams | "grade" | "genre" | "description",
-      value: number | string | Grade
+      value: number | string | Grade | Genre
     ) => {
       setParams(prev => {
         if (field === "quantity" || field === "price") {
@@ -71,7 +71,7 @@ export const useEditSaleCardForm = (initialData: SaleCardDetailDto, onClose: () 
 
   // 장르 변경 핸들러
   const handleGenreChange = useCallback(
-    (value: string) => {
+    (value: Genre) => {
       updateParams("genre", value);
     },
     [updateParams]

--- a/src/types/filter.types.ts
+++ b/src/types/filter.types.ts
@@ -1,6 +1,6 @@
-import { Grade } from "./photocard.types";
+import { Genre, Grade } from "./photocard.types";
 
 // 필터 관련 타입 정의
 export type GradeFilter = "default" | Grade;
-export type GenreFilter = "default" | "TRAVEL" | "LANDSCAPE" | "PORTRAIT" | "OBJECT";
+export type GenreFilter = "default" | Genre;
 export type TradeStatusFilter = "default" | "ON_SALE" | "SOLD_OUT" | "PENDING";

--- a/src/types/photocard.types.ts
+++ b/src/types/photocard.types.ts
@@ -1,4 +1,5 @@
 export type Grade = "COMMON" | "RARE" | "SUPER_RARE" | "LEGENDARY";
+export type Genre = "TRAVEL" | "LANDSCAPE" | "PORTRAIT" | "OBJECT";
 export type CardType = "details" | "list";
 export type AmountText = "잔여" | "수량" | "보유량";
 export type SaleCardStatus = "ON_SALE" | "CANCELED" | "SOLD_OUT";
@@ -9,7 +10,7 @@ export type SaleCardStatus = "ON_SALE" | "CANCELED" | "SOLD_OUT";
 export interface MyPhotoCardDto {
   id: string;
   grade: Grade;
-  genre: string;
+  genre: Genre;
   name: string;
   price: number;
   availableAmount: number;
@@ -27,7 +28,7 @@ export interface SaleCardDetailDto {
   imageUrl: string;
   name: string;
   grade: Grade;
-  genre: string;
+  genre: Genre;
   description: string;
   price: number;
   availableAmount: number;
@@ -35,7 +36,7 @@ export interface SaleCardDetailDto {
   totalOwnAmount: number;
   exchangeDetail: {
     grade: Grade;
-    genre: string;
+    genre: Genre;
     description: string;
   };
   isMine: boolean;
@@ -51,7 +52,7 @@ export interface ExchangeCardDto {
   imageUrl: string;
   name: string;
   grade: Grade;
-  genre: string;
+  genre: Genre;
   price: number;
   description: string;
   createdAt: string;
@@ -61,6 +62,7 @@ export interface ExchangeCardDto {
  * 판매 포토카드 교환 목록 조회 API 응답 타입
  */
 export interface SaleCardExchangeListDto {
+  saleCardId: string;
   isMine: boolean;
   receivedOffers: ExchangeCardDto[] | null;
   myOffers: ExchangeCardDto[] | null;
@@ -89,7 +91,7 @@ export interface UpdateSaleCardResponseDto {
   status: SaleCardStatus;
   name: string;
   grade: Grade;
-  genre: string;
+  genre: Genre;
   price: number;
   image: string;
   remaining: number;

--- a/src/types/photocard.types.ts
+++ b/src/types/photocard.types.ts
@@ -76,7 +76,7 @@ export interface UpdateSaleCardBodyParams {
   price: number;
   exchangeOffer: {
     grade: Grade;
-    genre: string;
+    genre: Genre;
     description: string;
   };
 }


### PR DESCRIPTION
## 📌 개요

- 포토카드 관련 api 응답 타입 수정 및 CommonDropdown 컴포넌트 옵션 타입 수정

## ✨ 주요 변경 사항

- 기존 photocard.type.ts 파일에서 포토카드 관련 응답 중 genre의 타입을 string으로 지정했었는데, Genre 타입을 추가하고 모두 통일함
- CommonDropdown 컴포넌트에서도 옵션 선택하여 api 요청 보낼때 Grade, Genre 타입으로 들어가도록 수정
- 장르 데이터를 상용하는 CardHeader 컴포넌트에서 영어로 받은 데이터를 한글로 매핑하는 함수 추가, ui 적용
