### PR TITLE
Add/queryKey 추가 및 마켓플레이스 상세페이지 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^4.1.3",
+        "@tanstack/react-query": "^5.71.5",
         "axios": "^1.8.4",
         "clsx": "^2.1.1",
         "immer": "^10.1.1",
@@ -4902,6 +4903,32 @@
         "lightningcss": "1.29.2",
         "postcss": "^8.4.41",
         "tailwindcss": "4.0.15"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.71.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.71.5.tgz",
+      "integrity": "sha512-XOQ5SyjCdwhxyLksGKWSL5poqyEXYPDnsrZAzJm2LgrMm4Yh6VOrfC+IFosXreDw9HNqC11YAMY3HlfHjNzuaA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.71.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.71.5.tgz",
+      "integrity": "sha512-WpxZWy4fDASjY+iAaXB+aY+LC95PQ34W6EWVkjJ0hdzWWbczFnr9nHvHkVDpwdR18I1NO8igNGQJFrLrgyzI8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.71.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^4.1.3",
+    "@tanstack/react-query": "^5.71.5",
     "axios": "^1.8.4",
     "clsx": "^2.1.1",
     "immer": "^10.1.1",

--- a/src/app/market/[id]/page.tsx
+++ b/src/app/market/[id]/page.tsx
@@ -37,13 +37,13 @@ export default function PhotoCardDetailPage() {
   };
 
   const exchangeListData = {
-    saleCardId: "acg",
+    saleId: "acg",
     isMine: false,
     // receivedOffers: null,
     receivedOffers: [
       {
         id: "acg",
-        offererNickname: "룰루",
+        creatorNickname: "룰루",
         imageUrl: "/assets/images/mock3.png",
         name: "how far i'll go",
         grade: "SUPER_RARE" as Grade,
@@ -55,7 +55,7 @@ export default function PhotoCardDetailPage() {
       },
       {
         id: "acwegas",
-        offererNickname: "난나",
+        creatorNickname: "난나",
         imageUrl: "/assets/images/mock2.png",
         name: "스페인 여행",
         grade: "COMMON" as Grade,
@@ -66,7 +66,7 @@ export default function PhotoCardDetailPage() {
       },
       {
         id: "acgfgg",
-        offererNickname: "락토핏",
+        creatorNickname: "락토핏",
         imageUrl: "/assets/images/mock3.png",
         name: "how far i'll go",
         grade: "SUPER_RARE" as Grade,
@@ -77,7 +77,7 @@ export default function PhotoCardDetailPage() {
       },
       {
         id: "acwegasssss",
-        offererNickname: "금명이",
+        creatorNickname: "금명이",
         imageUrl: "/assets/images/mock2.png",
         name: "스페인 여행",
         grade: "COMMON" as Grade,
@@ -88,7 +88,7 @@ export default function PhotoCardDetailPage() {
       },
       {
         id: "acgasdfg",
-        offererNickname: "관식",
+        creatorNickname: "관식",
         imageUrl: "/assets/images/mock3.png",
         name: "how far i'll go",
         grade: "SUPER_RARE" as Grade,
@@ -99,7 +99,7 @@ export default function PhotoCardDetailPage() {
       },
       {
         id: "acwegaasssssdf",
-        offererNickname: "판다",
+        creatorNickname: "판다",
         imageUrl: "/assets/images/mock2.png",
         name: "스페인 여행",
         grade: "COMMON" as Grade,
@@ -110,7 +110,7 @@ export default function PhotoCardDetailPage() {
       },
       {
         id: "acgasdfsdf",
-        offererNickname: "코어",
+        creatorNickname: "코어",
         imageUrl: "/assets/images/mock3.png",
         name: "how far i'll go",
         grade: "SUPER_RARE" as Grade,
@@ -124,7 +124,7 @@ export default function PhotoCardDetailPage() {
     myOffers: [
       {
         id: "acg",
-        offererNickname: "룰루",
+        creatorNickname: "룰루",
         imageUrl: "/assets/images/mock3.png",
         name: "how far i'll go",
         grade: "SUPER_RARE" as Grade,
@@ -136,7 +136,7 @@ export default function PhotoCardDetailPage() {
       },
       {
         id: "acwegas",
-        offererNickname: "난나",
+        creatorNickname: "난나",
         imageUrl: "/assets/images/mock2.png",
         name: "스페인 여행",
         grade: "COMMON" as Grade,
@@ -147,7 +147,7 @@ export default function PhotoCardDetailPage() {
       },
       {
         id: "acgfgg",
-        offererNickname: "락토핏",
+        creatorNickname: "락토핏",
         imageUrl: "/assets/images/mock3.png",
         name: "how far i'll go",
         grade: "SUPER_RARE" as Grade,

--- a/src/components/common/input/CommonDropdownInput.tsx
+++ b/src/components/common/input/CommonDropdownInput.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { Grade, Genre } from "@/types/photocard.types";
 import Image from "next/image";
 
@@ -48,21 +47,26 @@ const dropdownOptions: Record<
 interface CommonDropdownProps<T extends keyof DropdownType> {
   inputLabel: T;
   value?: DropdownType[T]["value"];
+  isOpen: boolean;
+  onOpen: () => void;
+  onClose: () => void;
   onChange: (value: DropdownType[T]["value"]) => void;
 }
 
 export default function CommonDropdownInput<T extends keyof DropdownType>({
   inputLabel,
   value,
+  isOpen,
+  onOpen,
+  onClose,
   onChange,
 }: CommonDropdownProps<T>) {
-  const [isOpen, setIsOpen] = useState(false);
   const { label, placeholder, options } = dropdownOptions[inputLabel];
 
   const handleOptionClick = (key: string, event: React.MouseEvent) => {
     event.stopPropagation();
     onChange(key as DropdownType[T]["value"]);
-    setIsOpen(false);
+    onClose();
   };
 
   const selectedText = value ? options[value as keyof typeof options] : "";
@@ -73,7 +77,7 @@ export default function CommonDropdownInput<T extends keyof DropdownType>({
         {label}
       </label>
 
-      <div className="relative" onClick={() => setIsOpen(prev => !prev)}>
+      <div className="relative" onClick={() => (isOpen ? onClose() : onOpen())}>
         <input
           type="text"
           value={selectedText}
@@ -92,8 +96,15 @@ export default function CommonDropdownInput<T extends keyof DropdownType>({
             isOpen ? "rotate-180" : ""
           }`}
         />
-        {isOpen && (
-          <ul className="bg-dark w-full border border-gray-200 rounded-[2px] p-[10px] mt-1 z-10 absolute">
+
+        <div
+          className={`absolute w-full mt-1 transition-all duration-200 ease-in-out origin-top ${
+            isOpen
+              ? "opacity-100 scale-y-100 translate-y-0 z-50"
+              : "opacity-0 scale-y-0 -translate-y-2 pointer-events-none"
+          }`}
+        >
+          <ul className="bg-dark w-full border border-gray-200 rounded-[2px] p-[10px] relative">
             {Object.entries(options).map(([key, text]) => (
               <li
                 key={key}
@@ -105,7 +116,7 @@ export default function CommonDropdownInput<T extends keyof DropdownType>({
               </li>
             ))}
           </ul>
-        )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/market/detail/supplier/SaleCardEditForm.tsx
+++ b/src/components/market/detail/supplier/SaleCardEditForm.tsx
@@ -10,7 +10,7 @@ import AmountInput from "@/components/common/input/AmountInput";
 import PriceInput from "@/components/common/input/PriceInput";
 import CommonDropdownInput from "@/components/common/input/CommonDropdownInput";
 import CommonTextarea from "@/components/common/input/CommonTextarea";
-// import { useState } from "react";
+import { useState } from "react";
 
 interface SaleCardEditFormProps {
   data: SaleCardDetailDto;
@@ -30,6 +30,24 @@ export const SaleCardEditForm: React.FC<SaleCardEditFormProps> = ({ data, onClos
     handleUpdateSaleCard,
   } = useEditSaleCardForm(data, onClose);
 
+  // 현재 열린 드롭다운 상태 관리
+  const [openDropdown, setOpenDropdown] = useState<"grade" | "genre" | null>(null);
+
+  const handleDropdownOpen = (dropdownType: "grade" | "genre") => {
+    setOpenDropdown(dropdownType);
+  };
+
+  const handleDropdownClose = () => {
+    setOpenDropdown(null);
+  };
+
+  const cardHeaderProps = {
+    grade: data.grade,
+    genre: data.genre,
+    creator: data.userNickname,
+    cardType: "details" as CardType,
+  };
+
   // XXX: 취소 컨펌 모달 띄울지 고민
   // -> ResponsiveForm 컴포넌트 백드랍 클릭시에도 취소 확인 모달을 띄워줘야하는데, 부모 컴포넌트로 전달할 방법 모르겠어서 일단 보류
   // const [isCancelEditModalOpen, setIsCancelEditModalOpen] = useState(false);
@@ -39,13 +57,6 @@ export const SaleCardEditForm: React.FC<SaleCardEditFormProps> = ({ data, onClos
   // const handleCancelEditModalClose = () => {
   //   setIsCancelEditModalOpen(false);
   // };
-
-  const cardHeaderProps = {
-    grade: data.grade,
-    genre: data.genre,
-    creator: data.userNickname,
-    cardType: "details" as CardType,
-  };
 
   return (
     <div className="w-[100%] h-full flex flex-col ">
@@ -115,11 +126,17 @@ export const SaleCardEditForm: React.FC<SaleCardEditFormProps> = ({ data, onClos
                   inputLabel="grade"
                   value={params.exchangeOffer.grade}
                   onChange={handleGradeChange}
+                  isOpen={openDropdown === "grade"}
+                  onOpen={() => handleDropdownOpen("grade")}
+                  onClose={handleDropdownClose}
                 />
                 <CommonDropdownInput
                   inputLabel="genre"
                   value={params.exchangeOffer.genre}
                   onChange={handleGenreChange}
+                  isOpen={openDropdown === "genre"}
+                  onOpen={() => handleDropdownOpen("genre")}
+                  onClose={handleDropdownClose}
                 />
               </div>
               <CommonTextarea

--- a/src/components/market/list/MarketplaceHeader.tsx
+++ b/src/components/market/list/MarketplaceHeader.tsx
@@ -58,7 +58,7 @@ export default function MarketplaceHeader({
     // isSoldOut 필터링
     if (isSoldOut !== "default") {
       filteredCards = filteredCards.filter(card =>
-        isSoldOut === "soldOut" ? card.status === "SOLD_OUT" : card.status !== "SOLD_OUT"
+        isSoldOut === "SOLD_OUT" ? card.status === "SOLD_OUT" : card.status !== "SOLD_OUT"
       );
     }
     // 정렬

--- a/src/hooks/market/detail/useExchangeCardService.tsx
+++ b/src/hooks/market/detail/useExchangeCardService.tsx
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { photoCardKeys } from "../../../utils/queryKeys";
+import { getSaleCardExchangeList } from "@/services/market/getSaleCardExchangeList";
+
+export const useExchangeCardService = (saleId: string) => {
+  const { data, isLoading, error } = useQuery({
+    queryKey: photoCardKeys.exchangeCardList(saleId),
+    queryFn: () => getSaleCardExchangeList(saleId),
+  });
+
+  return {
+    data,
+    isLoading,
+    error,
+  };
+};

--- a/src/types/filter.types.ts
+++ b/src/types/filter.types.ts
@@ -1,6 +1,7 @@
-import { Genre, Grade } from "./photocard.types";
+import { Genre, Grade, TradeStatus } from "./photocard.types";
 
 // 필터 관련 타입 정의
+// XXX: 여기 백쪽에서는 굳이 grade=default 이런식으로 쿼리를 보내지 않아도 그냥 값을 안보내면 전체조회라고 합니다! 그래서 필터타입은 사용하지 않아도 될 것 같은데 우선 파일은 그대로 살려두겠습니다. 쿼리키 사용해서 api 요청보낼때 문제가 생기면 수정해서 사용하시면 될 것 같습니다.
 export type GradeFilter = "default" | Grade;
 export type GenreFilter = "default" | Genre;
-export type TradeStatusFilter = "default" | "ON_SALE" | "SOLD_OUT" | "PENDING";
+export type TradeStatusFilter = "default" | TradeStatus;

--- a/src/types/photocard.types.ts
+++ b/src/types/photocard.types.ts
@@ -1,8 +1,10 @@
 export type Grade = "COMMON" | "RARE" | "SUPER_RARE" | "LEGENDARY";
 export type Genre = "TRAVEL" | "LANDSCAPE" | "PORTRAIT" | "OBJECT";
+export type Sort = "recent" | "old" | "cheap" | "expensive";
+export type SaleCardStatus = "ON_SALE" | "CANCELED" | "SOLD_OUT"; // TODO: 여기 수정응답에서 쓰이는데 수정사항 있는지 확인 필요 + 쿼리키 saleList 에서도 그냥 이거 사용. 만약 수정하게되면 쿼리키쪽에 문제없는지 확인 필요
+export type TradeStatus = "ON_SALE" | "SOLD_OUT" | "PENDING";
 export type CardType = "details" | "list";
 export type AmountText = "잔여" | "수량" | "보유량";
-export type SaleCardStatus = "ON_SALE" | "CANCELED" | "SOLD_OUT";
 
 /**
  * 마이 갤러리 조회 API 응답 - 포토카드 타입

--- a/src/types/photocard.types.ts
+++ b/src/types/photocard.types.ts
@@ -48,7 +48,7 @@ export interface SaleCardDetailDto {
  */
 export interface ExchangeCardDto {
   id: string;
-  offererNickname: string;
+  creatorNickname: string;
   imageUrl: string;
   name: string;
   grade: Grade;
@@ -62,7 +62,7 @@ export interface ExchangeCardDto {
  * 판매 포토카드 교환 목록 조회 API 응답 타입
  */
 export interface SaleCardExchangeListDto {
-  saleCardId: string;
+  saleId: string;
   isMine: boolean;
   receivedOffers: ExchangeCardDto[] | null;
   myOffers: ExchangeCardDto[] | null;

--- a/src/utils/invalidateQueryKeys.ts
+++ b/src/utils/invalidateQueryKeys.ts
@@ -1,0 +1,22 @@
+import { QueryClient } from "@tanstack/react-query";
+import { photoCardKeys } from "./queryKeys";
+
+// XXX: 로그인/로그아웃 시 기존에 받아왔던 리스트 등 데이터 무효화 필요 - 이때 한번에 관련 쿼리를 한번에 invalidate하는 함수입니다.
+// 무효화 필요한 경우 예시 : 판매 상태, 소유 여부 등 변경될 수 있음
+
+/**
+ * 로그인 등 유저 관련 정보 업데이트 시 관련 쿼리 모두 무효화
+ * @param queryClient
+ */
+export const invalidateQueryKeys = (queryClient: QueryClient) => {
+  queryClient.invalidateQueries({ queryKey: photoCardKeys.all });
+  // TODO: 유저 포인트나 알림 등도 추가될 수 있을 듯
+};
+
+/**
+ * 로그아웃 시 관련 쿼리 캐시 초기화
+ * @param queryClient
+ */
+export const removeQueryKeys = (queryClient: QueryClient) => {
+  queryClient.removeQueries({ queryKey: photoCardKeys.all });
+};

--- a/src/utils/queryKeys.ts
+++ b/src/utils/queryKeys.ts
@@ -1,0 +1,27 @@
+import { Genre, Grade, SaleCardStatus, Sort, TradeStatus } from "@/types/photocard.types";
+
+// XXX: 목록 조회시 필요한 필터 파라미터들을 일단 임의로 넣어두었습니다. 세정님 하윤님 필터링 사용할때 타입이나 뭐 이상있으면 필요에맞게 수정해서 사용하시면됩니다!
+
+export const photoCardKeys = {
+  all: ["photoCard"] as const,
+
+  // 마켓플레이스 메인 - 검색 조건(검색어, 등급, 장르, 상태, 정렬)
+  saleList: (params: {
+    keyword: string;
+    grade: Grade;
+    genre: Genre;
+    status: SaleCardStatus;
+    sort: Sort;
+  }) => [...photoCardKeys.all, "saleList", params] as const,
+
+  // 교환 포토카드 목록
+  exchangeCardList: (saleId: string) => [...photoCardKeys.all, "exchangeCardList", saleId] as const,
+
+  // 마이갤러리 목록 - 검색 조건(검색어, 등급, 장르)
+  myPhotoList: (params: { keyword: string; grade: Grade; genre: Genre }) =>
+    [...photoCardKeys.all, "myPhotoList", params] as const,
+
+  // 나의 판매 포토카드 목록 - 검색 조건(검색어, 등급, 장르, 판매 상태)
+  mySaleList: (params: { keyword: string; grade: Grade; genre: Genre; status: TradeStatus }) =>
+    [...photoCardKeys.all, "mySaleList", params] as const,
+};


### PR DESCRIPTION
## 📌 개요

- 포토카드 관련해서 공유할 queryKey 파일 추가
- 상세페이지 수정 폼 드롭다운 리팩토링

## 📢 공유 사항(다른 팀원들도 알아두어야 할 것들)

- utils 폴더에 `queryKeys.ts` 파일과 `invalidateQueryKeys.ts` 파일을 추가했습니다.
- queryKeys 파일 아래 제가 사용할 exchangeCardList 외에 세정님과 하윤님이 사용할 키들은 쿼리파라미터를 제가 임의로 필요해보이는것들로 넣어둔 상태입니다. api 연결하면서 필터랑 잘 연동되는지 확인해보고 맞춰서 수정하시면됩니다! @celina823 @hay-oon 
- 로그인/로그아웃 시 reactQuery에 담아뒀던 기존 데이터 캐시를 무효화할 때 한번에 관리하기 위해 `invalidateQueryKeys.ts`파일을 추가했습니다. 회원가입/로그인/로그아웃 성공했을 때 로직에 invalidateQueryKeys() 또는 removeQueryKeys()를 추가해주시면 됩니다. @koseha @Obsessive-Curiosity 
- 지금은 포토카드 조회관련 쿼리키만 있는데 이후 알림이나 포인트 등을 리액트쿼리로 조회한다면, queryKeys 파일에 새로 키를 만들고, invalidateQueryKeys 파일에도 같이 추가해주시면됩니다.


- 기존 판매 포토카드 수정 폼에서 드롭다운이 동시에 열리지않도록 수정 + 애니메이션 추가
