### PR TITLE
fix: ResponsiveMyPhotoList 컨텐츠 영역 스크롤 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,7 +16,6 @@ export default async function RootLayout({ children }: { children: React.ReactNo
     <html lang="ko" className={`${baskinBold.variable}`}>
       <body>
         <AuthInitializer>
-          {/* 스낵바 팝업 전역 상태로 관리 */}
           <ReactQueryProvider>
             <ReactQueryDevtools initialIsOpen={false} />
             {children}

--- a/src/components/common/responsiveLayout/responsiveMyPhotoList/MyPhotoFilter.tsx
+++ b/src/components/common/responsiveLayout/responsiveMyPhotoList/MyPhotoFilter.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from "react";
+import { GradeFilter, GenreFilter } from "@/types/filter.types";
+import PhotoFilterSection from "@/components/my-page/my-photo/PhotoFilterSection";
+import { useMyPhotoCards } from "@/hooks/my-page/useMyPhotoCards";
+import { Grade, Genre } from "@/types/photocard.types";
+import { CircularProgress } from "../../loading/CircularProgress";
+import PhotoCardList from "@/components/my-page/my-photo/PhotoCardList";
+
+interface MyPhotoFilterProps {
+  onCardClick?: (cardId: string) => void;
+}
+
+const MyPhotoFilter: React.FC<MyPhotoFilterProps> = ({ onCardClick }) => {
+  const [gradeFilter, setGradeFilter] = useState<GradeFilter>("default");
+  const [genreFilter, setGenreFilter] = useState<GenreFilter>("default");
+  const [searchQuery, setSearchQuery] = useState<string>("");
+
+  // 필터 값을 실제 API 파라미터에 맞게 변환 - default를 undefined로 변환
+  const getFilterParam = <T extends Grade | Genre>(filter: string): T | undefined => {
+    return filter === "default" ? undefined : (filter as T);
+  };
+
+  // React Query 훅 사용
+  const { myPhotos, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useMyPhotoCards({
+    keyword: searchQuery,
+    grade: getFilterParam<Grade>(gradeFilter),
+    genre: getFilterParam<Genre>(genreFilter),
+  });
+
+  const handleSearch = (query: string) => {
+    setSearchQuery(query);
+  };
+
+  const responsiveMyPhotoListGrid = "grid grid-cols-2 gap-[5px] md:gap-5 lg:gap-10";
+
+  return (
+    <div className="w-[100%] flex flex-col gap-[4px] md:gap-[20px] h-[calc(100vh-340px)]">
+      {/* 필터 영역 */}
+      <div className="flex-shrink-0">
+        <PhotoFilterSection
+          gradeFilter={gradeFilter}
+          genreFilter={genreFilter}
+          onGradeFilterChange={setGradeFilter}
+          onGenreFilterChange={setGenreFilter}
+          onSearch={handleSearch}
+        />
+      </div>
+
+      {/* 리스트 - 스크롤 영역 */}
+      <div className={contentScrollWrapperSx}>
+        {isLoading ? (
+          <CircularProgress />
+        ) : myPhotos.length > 0 ? (
+          // 데이터 있는 경우
+          <PhotoCardList
+            className={responsiveMyPhotoListGrid}
+            photoCards={myPhotos}
+            onCardClick={onCardClick}
+            onLoadMore={fetchNextPage}
+            hasNextPage={hasNextPage}
+            isFetchingNextPage={isFetchingNextPage}
+          />
+        ) : (
+          // 데이터 없는 경우
+          <div className="flex justify-center items-center py-20">
+            <div className="text-white text-lg">포토카드가 없습니다.</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MyPhotoFilter;
+
+const contentScrollWrapperSx =
+  "w-[100%] h-full overflow-y-auto lg:pr-[40px] [&::-webkit-scrollbar]:w-[0px] lg:[&::-webkit-scrollbar]:w-[8px] [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-gray-400 [&::-webkit-scrollbar-thumb]:rounded-full";

--- a/src/components/common/responsiveLayout/responsiveMyPhotoList/MyPhotoListContent.tsx
+++ b/src/components/common/responsiveLayout/responsiveMyPhotoList/MyPhotoListContent.tsx
@@ -1,14 +1,12 @@
 import { MyPhotoCardDto } from "@/types/photocard.types";
 import { useMyPhotoCards } from "@/hooks/my-page/useMyPhotoCards";
-import CardFilter from "@/components/my-page/my-photo/PhotoCardFilter";
+import MyPhotoFilter from "./MyPhotoFilter";
 
 interface MyPhotoListContentProps {
   title: string;
   onCardClick: (cardId: string, cardData: MyPhotoCardDto) => void;
 }
 
-// XXX: 하윤님 마이갤러리 api + 컴포넌트로 보유하고 있는 카드 보여줌.
-// TODO: 무한스크롤 안됨 -> 스크롤 영역 다시 설정 필요
 export const MyPhotoListContent: React.FC<MyPhotoListContentProps> = ({ title, onCardClick }) => {
   // React Query 훅 사용 (초기 로딩용)
   const { myPhotos } = useMyPhotoCards();
@@ -36,13 +34,7 @@ export const MyPhotoListContent: React.FC<MyPhotoListContentProps> = ({ title, o
           <div className={titleSx}>{title}</div>
         </div>
 
-        {/* 필터 + 카드 리스트 영역 */}
-        <div className="w-[100%] flex flex-col h-[calc(100vh-340px)]">
-          <CardFilter
-            onCardClick={handleCardClick}
-            className="grid grid-cols-2 mt-[4px] md:mt-[20px] gap-[5px] md:gap-5 lg:gap-10"
-          />
-        </div>
+        <MyPhotoFilter onCardClick={handleCardClick} />
       </div>
     </div>
   );


### PR DESCRIPTION
## 📌 개요

- ResponsiveMyPhotoList 리스트 영역 스크롤 수정

## ✨ 주요 변경 사항

- 판매등록/교환제시 할 때 보유 카드 리스트를 보여주는 반응형 모달, ResponsiveMyPhotoList 안에 있는 MyPhotoListContent 컴포넌트에서 필터+그리드 컴포넌트를 하윤님 걸로 재사용했더니 스크롤이 내려가지 않는 문제가 있었음
- 하윤님 마이갤러리 컴포넌트 참고하여 새로 컴포넌트 추가하여 반응형 모달 내에서도 스크롤 가능하도록 수정했습니다.

## 📢 공유 사항(다른 팀원들도 알아두어야 할 것들)

- @celina823 @hay-oon 세정님 지금 올라간 버전 ResponsiveMyPhotoList 사용해서 판매등록 만드시면 됩니다! 하윤님 마이갤러리 페이지에서도 판매등록 버튼있던데, 세정님이 완성하시면 그거 그대로 사용하실수있게 잘 만들어주시면 될거같아요~ㅎㅎ
- 지금 모바일 필터에서 옵션 선택함에따라 개수 보여지는 부분이 이상해요. 
    - 여러 옵션을 선택했을 때, 필터모달 버튼에는[2개 카드 보기]로 되어있는데 실제 조회해보면 1개만 온다거나,
    - 내가 가지고 있는 전체 카드가 7개이고, 두가지 옵션을 선택했다가 한개만 해제했을 때, 해제한 쪽 전체 개수는 기존 전체 개수대로 7개가 보이는데, 옵션을 선택하지않은 쪽 전체에는 선택한 옵션 개수가 전체에 보인다던가,
    - 이게 백에서 보내주는 개수 데이터의 문제인지, 아니면 프론트에서 데이터 받아와서 ui 업데이트해줄떄 문제인진 모르겠는데 확인해야할것같아요-!
    - 만약 마켓플레이스 전체조회쪽에는 해당 문제가 없다면, 마이갤러리 조회할떄 사용하는 재완님 api 쪽 문제일수도있을것같은데, 마켓플레이스 전체쪽에도 같은 문제가 있으면 한샘님 api도 같이 확인해봐야할것같네요
