### PR TITLE
fix: 헤더 모바일 title이 태블릿, 데스크탑에서도 적용되는 문제 해결

### DIFF
--- a/src/components/gnb/Header.tsx
+++ b/src/components/gnb/Header.tsx
@@ -29,6 +29,7 @@ const Header = () => {
   const isLogin = !!userInfo;
 
   const title = PATH_TITLE.find(([re]) => re.test(pathname))?.[1];
+  const hasTitle = title !== undefined;
 
   const {
     data, // ← 여기!
@@ -78,9 +79,9 @@ const Header = () => {
     <div className="flex justify-between mx-auto max-w-[1520px] w-full items-center h-[60px] md:h-[70px] px-[15px] md:px-[20px] lg:h-[80px] z-10">
       <button
         className="md:hidden lg:hidden cursor-pointer"
-        onClick={title ? handleBack : handleProfileOpen}
+        onClick={hasTitle ? handleBack : handleProfileOpen}
       >
-        {title ? (
+        {hasTitle ? (
           <Image src={"/assets/icons/back.png"} alt="menu" width={20} height={20} />
         ) : (
           <Image src={"/assets/icons/menu.png"} alt="menu" width={16} height={16} />
@@ -88,8 +89,13 @@ const Header = () => {
       </button>
       <Link href={"/"}>
         <Title>
-          {title ? (
-            <>{title}</>
+          {hasTitle ? (
+            <>
+              <div className="md:hidden">{title}</div>
+              <div className="hidden md:block">
+                최애<span className="text-main">의</span>포토
+              </div>
+            </>
           ) : (
             <>
               최애<span className="text-main">의</span>포토
@@ -98,7 +104,7 @@ const Header = () => {
         </Title>
       </Link>
       <div className="w-[16px]">
-        {isLogin && !title && (
+        {isLogin && !hasTitle && (
           <button
             className="md:hidden lg:hidden cursor-pointer relative"
             onClick={handleNotificationOpen}


### PR DESCRIPTION
## 📌 개요

- 헤더 모바일 화면에서 특정 페이지 타이틀이 태블릿, 데스크탑에서도 적용되는 문제 해결

## ✨ 주요 변경 사항

- 

## 📢 공유 사항(다른 팀원들도 알아두어야 할 것들)

- 

## 🔗 관련 이슈

-

## 🖼️ 스크린샷

마이갤러리 (태블릿, 데스크탑)
![image](https://github.com/user-attachments/assets/055bb47f-9279-4f57-a31f-0b06390a9eff)

마이갤러리 (모바일)
![image](https://github.com/user-attachments/assets/63aeec15-afae-4835-ab03-e0a5cb4407c9)

나의 판매 포토카드 (태블릿, 데스크탑)
![image](https://github.com/user-attachments/assets/73580ccb-5856-4475-8923-d3c4829c581a)

나의 판매 포토카드 (모바일)
![image](https://github.com/user-attachments/assets/ce6ae643-17f4-42dd-9ddf-70e94d36dcc3)

나의 판매 포토카드 상세 (태블릿, 데스크탑)
![image](https://github.com/user-attachments/assets/39276c4a-088c-490d-9e15-d14758584d4b)

나의 판매 포토카드 상세 (모바일)
![image](https://github.com/user-attachments/assets/80395f45-0252-4812-8775-7a172c6c1599)
