### PR TITLE
refactor: 판매 등록 스낵바 메세지 수정 + 로그인페이지로 라우팅 기능 + 판매중 카드 스낵바 추가

### DIFF
--- a/src/app/market/MarketplacePageClient.tsx
+++ b/src/app/market/MarketplacePageClient.tsx
@@ -13,8 +13,11 @@ import { useState, useEffect } from "react";
 import { SaleCardDto, Grade, Genre, SaleCardStatus, Sort } from "@/types/photocard.types";
 import ResponsiveForm from "@/components/common/responsiveLayout/responsiveForm/ResponsiveForm";
 import { useSnackbarStore } from "@/store/useSnackbarStore";
+import { useRouter } from "next/navigation";
 
 export default function MarketplacePageClient() {
+  const router = useRouter();
+
   const defaultFilter = {
     keyword: "",
     grade: "default",
@@ -49,7 +52,9 @@ export default function MarketplacePageClient() {
 
   const handleOpenMyPhotoList = () => {
     if (!user) {
-      openSnackbar("ERROR", "로그인이 필요합니다.");
+      openSnackbar("ERROR", "로그인 후 이용해주세요.");
+      router.push("/auth/login");
+      setIsSellerPageOpen(false);
       return;
     }
     setIsSellerPageOpen(true);

--- a/src/components/market/list/seller/SaleForm.tsx
+++ b/src/components/market/list/seller/SaleForm.tsx
@@ -38,10 +38,18 @@ const SellForm = ({ data, onCancel, onSubmit }: SellFormProps) => {
       });
       // console.log("😏내가 입력한 데이터 확인용", requestData);
       await axiosClient.post("/market", requestData);
-      openSnackbar("SUCCESS", "판매 등록이 완료되었습니다!");
+      openSnackbar(
+        "SUCCESS",
+        `[${grade} | ${data.name}] ${quantity}장 판매 등록에 성공했습니다!`,
+        "판매 등록"
+      );
       onSubmit();
     } catch (error) {
-      openSnackbar("ERROR", "판매 등록에 실패했습니다. 다시 시도해주세요.");
+      openSnackbar(
+        "ERROR",
+        `[${grade} | ${data.name}] ${quantity}장 판매 등록에 실패했습니다.`,
+        "판매 등록"
+      );
       console.error("판매 등록 실패:", error);
     }
   };


### PR DESCRIPTION
## 📌 개요

- 판매자 모달 관련해서 [이전 PR](https://github.com/FS05-PART3-TEAM2/5-fav_photo-team2-fe/pull/85)에 호은님이 코멘트 주신 부분 수정했습니다.

## ✨ 주요 변경 사항

- 판매 등록 성공/실패 여부에 따른 스낵바 메세지 수정 
- 비로그인상태에서 판매하기 버튼 클릭 시, 로그인페이지로 라우팅 기능 추가
- 판매폼모달(SaleForm)에서 이미 판매중인 카드에 대한 스낵바 메세지 추가
- 
## 📢 공유 사항(다른 팀원들도 알아두어야 할 것들)

-

## 🔗 관련 이슈

-

## 🖼️ 스크린샷

- 이미 판매중인 카드에 대한 스낵바 메세지 추가
![image](https://github.com/user-attachments/assets/08d900e2-6cc0-438a-96cb-8d9d8bb3a6fc)

