### PR TITLE
fix: 포토카드 생성 로직 수정

### DIFF
--- a/src/app/my-photos/create/page.tsx
+++ b/src/app/my-photos/create/page.tsx
@@ -1,14 +1,8 @@
 import CreatePhotoCardForm from "@/components/my-page/my-photo/CreatePhotoCardForm";
-
-import { cookies } from "next/headers";
-
+// import { cookies } from "next/headers";
 export default async function Page() {
-  const cookieStore = await cookies();
-  const token = cookieStore.get("token")?.toString() ?? "";
+  // const cookieStore = await cookies();
+  // const cookie = cookieStore.get("token")?.value || "";
 
-  return (
-    <>
-      <CreatePhotoCardForm cookie={token} />
-    </>
-  );
+  return <CreatePhotoCardForm />;
 }

--- a/src/components/auth/AuthInitializer.tsx
+++ b/src/components/auth/AuthInitializer.tsx
@@ -9,6 +9,7 @@ export default async function AuthInitializer({ children }: { children: React.Re
   const cookie = (await cookieStore).toString();
   let userInfo = null;
 
+  // TODO: 쿠키없을 때도 me 보내지는거같은데 확인 필요
   try {
     const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/auth/me`, {
       headers: {

--- a/src/components/auth/AuthInitializer.tsx
+++ b/src/components/auth/AuthInitializer.tsx
@@ -8,22 +8,22 @@ export default async function AuthInitializer({ children }: { children: React.Re
   const cookieStore = cookies();
   const cookie = (await cookieStore).toString();
   let userInfo = null;
+  if (cookie) {
+    try {
+      const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/auth/me`, {
+        headers: {
+          cookie,
+        },
+      });
 
-  // TODO: 쿠키없을 때도 me 보내지는거같은데 확인 필요
-  try {
-    const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/auth/me`, {
-      headers: {
-        cookie,
-      },
-    });
-
-    userInfo = {
-      id: res.data.id,
-      nickname: res.data.nickname,
-      email: res.data.email,
-    } as UserInfo;
-  } catch (e) {
-    console.log("auth init error", e);
+      userInfo = {
+        id: res.data.id,
+        nickname: res.data.nickname,
+        email: res.data.email,
+      } as UserInfo;
+    } catch (e) {
+      console.log("auth init error", e);
+    }
   }
 
   return <AuthProvider userInfo={userInfo}>{children}</AuthProvider>;

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -18,12 +18,12 @@ export const AuthProvider = ({ userInfo, children }: props) => {
       if (userInfo) {
         setUser({ ...userInfo, points: userPoints?.points || 0 });
       } else {
-        logout();
+        await logout();
       }
     };
 
     checkAuth();
-  }, [userInfo, setUser, logout, userPoints]);
+  }, [userInfo, userPoints, setUser, logout]);
 
   // 포인트 로딩되는동안 0으로 뜨는거 방지
   if (isUserPointsLoading) {

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -30,7 +30,9 @@ export default function LoginForm() {
   const { openSnackbar } = useSnackbarStore(); // Snackbar 상태 업데이트 함수 가져오기
 
   useEffect(() => {
-    if (!state) return; // 초기 state가 null인 경우 처리
+    if (!state) return;
+
+    console.log("Login state:", state); // 디버깅을 위한 로그 추가
 
     if (state.status) {
       // 로그인 성공시
@@ -40,10 +42,9 @@ export default function LoginForm() {
       // useRouter()가 클라이언트 내에서 상태를 유지한 채로 이동
       // 완전히 새로고침 없이 페이지 이동이 되기 때문에 상태가 유지
     } else {
-      // 로그인 실패시
-      openSnackbar("ERROR", state.message); // Snackbar를 통해 에러 메시지 표시
+      openSnackbar("ERROR", state.message || "로그인에 실패했습니다.");
     }
-  }, [state, setUser, openSnackbar, router]);
+  }, [state, setUser, router]);
 
   return (
     <form action={formAction} className="w-form">

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -32,7 +32,6 @@ export default function LoginForm() {
   useEffect(() => {
     if (!state) return; // 초기 state가 null인 경우 처리
 
-    // TODO: 로그인했을 때 opensnackbar가 안뜨는걸보니 여기 로직을 안타는거같은데 확인 필요.
     if (state.status) {
       // 로그인 성공시
       setUser(state.user); // zustand store에 사용자 정보 저장
@@ -44,7 +43,7 @@ export default function LoginForm() {
       // 로그인 실패시
       openSnackbar("ERROR", state.message); // Snackbar를 통해 에러 메시지 표시
     }
-  }, [state, router, setUser, openSnackbar]);
+  }, [state, setUser, openSnackbar, router]);
 
   return (
     <form action={formAction} className="w-form">

--- a/src/components/common/input/constants.ts
+++ b/src/components/common/input/constants.ts
@@ -1,6 +1,6 @@
 export const FORM_CONFIG = {
   Input: {
-    photoCardName: {
+    name: {
       label: "포토카드 이름",
       placeholder: "포토카드 이름을 입력해 주세요",
     },
@@ -10,7 +10,7 @@ export const FORM_CONFIG = {
     stock: { label: "총 발행량", placeholder: "총 발행량을 입력해 주세요" },
   },
   Textarea: {
-    photoCardContent: {
+    description: {
       label: "포토카드 설명",
       placeholder: "카드 설명을 입력해 주세요",
       height: 220, // textarea height

--- a/src/components/common/responsiveLayout/ResponsiveModal.tsx
+++ b/src/components/common/responsiveLayout/ResponsiveModal.tsx
@@ -9,7 +9,7 @@ interface ModalProps {
 export default function ResponsiveModal({ onClose, children }: ModalProps) {
   return (
     // 오버레이
-    <div className="fixed inset-0 z-50">
+    <div className="fixed inset-0 z-100">
       <div className="fixed inset-0 bg-black/80" onClick={onClose} />
 
       {/* modal */}

--- a/src/components/gnb/Header.tsx
+++ b/src/components/gnb/Header.tsx
@@ -67,10 +67,15 @@ const Header = () => {
 
   const handleProfileOpen = () => setIsProfileOpen(prev => !prev);
   const handleNotificationOpen = () => setIsNotificationOpen(prev => !prev);
-  const handleLogout = () => {
-    logout();
-    removeQueryKeys(queryClient);
-    openSnackbar("SUCCESS", "로그아웃 완료되었습니다."); // Snackbar를 통해 에러 메시지 표시
+  const handleLogout = async () => {
+    try {
+      await logout(); // XXX: 로그아웃 시 userStore가 초기화 되기 전에 로그아웃 알림 떠버려서 랜덤박스 요청 보내지던 이슈 해결
+      removeQueryKeys(queryClient);
+      openSnackbar("SUCCESS", "로그아웃 완료되었습니다.");
+    } catch (error) {
+      openSnackbar("ERROR", "로그아웃 중 오류가 발생했습니다.");
+      throw error;
+    }
   };
   const handleBack = () => {
     router.back();

--- a/src/components/my-page/my-photo/CreatePhotoCardForm.tsx
+++ b/src/components/my-page/my-photo/CreatePhotoCardForm.tsx
@@ -26,13 +26,13 @@ export default function CreatePhotoCardForm() {
     resolver: zodResolver(createPhotoCardSchema),
     mode: "onChange",
     defaultValues: {
-      photoCardName: "",
+      name: "",
       grade: "",
       genre: "",
       price: "",
       stock: Grade.COMMON,
       image: undefined,
-      photoCardContent: "",
+      description: "",
     },
   });
 
@@ -54,12 +54,12 @@ export default function CreatePhotoCardForm() {
 
     // FormData 구성
     const formData = new FormData();
-    formData.append("photoCardName", data.photoCardName);
+    formData.append("name", data.name);
     formData.append("grade", data.grade);
     formData.append("genre", data.genre);
     formData.append("stock", data.stock.toString());
     formData.append("price", data.price);
-    formData.append("photoCardContent", data.photoCardContent);
+    formData.append("description", data.description);
     if (data.image) {
       formData.append("image", data.image); // File 객체 추가
     }
@@ -83,14 +83,14 @@ export default function CreatePhotoCardForm() {
       const { userPhotoCardId } = response.data;
       openSnackbar(
         "SUCCESS",
-        `[${data.grade} | ${data.photoCardName}] 포토카드 생성에 성공했습니다.`,
+        `[${data.grade} | ${data.name}] 포토카드 생성에 성공했습니다.`,
         "포토카드 생성"
       );
       router.push(`/my-photos/${userPhotoCardId}`);
     } catch (error) {
       openSnackbar(
         "ERROR",
-        `[${data.grade} | ${data.photoCardName}] 포토카드 생성에 실패했습니다.`,
+        `[${data.grade} | ${data.name}] 포토카드 생성에 실패했습니다.`,
         "포토카드 생성"
       );
       throw error;
@@ -101,13 +101,13 @@ export default function CreatePhotoCardForm() {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="w-form">
-      <Input name="photoCardName" control={control} />
+      <Input name="name" control={control} />
       <Dropdown name="grade" control={control} />
       <Dropdown name="genre" control={control} />
       <Input name="price" control={control} />
       <Input name="stock" control={control} hidden readOnly />
       <Upload name="image" control={control} />
-      <Textarea name="photoCardContent" control={control} />
+      <Textarea name="description" control={control} />
 
       <ThinBtn type="submit" disabled={!isValid || isPending} className="mt-[10px]">
         {isPending ? "생성 중..." : "생성하기"}

--- a/src/lib/actions/login.action.ts
+++ b/src/lib/actions/login.action.ts
@@ -63,5 +63,10 @@ export default async function loginAction(_: unknown, formData: FormData) {
 
   const result = await login({ email, password });
 
-  return result;
+  // 상태 객체를 명시적으로 반환
+  return {
+    status: result.status,
+    message: result.message,
+    user: result.user,
+  };
 }

--- a/src/schema/formSchema.ts
+++ b/src/schema/formSchema.ts
@@ -25,12 +25,12 @@ export type SignupFormSchema = z.infer<typeof signupSchema>;
 
 // 포토카드 생성 폼 스키마
 export const createPhotoCardSchema = InputSchema.pick({
-  photoCardName: true,
+  name: true,
   grade: true,
   genre: true,
   price: true,
   stock: true,
   image: true,
-  photoCardContent: true,
+  description: true,
 });
 export type CreatePhotoCardFormSchema = z.infer<typeof createPhotoCardSchema>; // 포토카드 생성 폼 스키마 타입

--- a/src/schema/inputSchema.ts
+++ b/src/schema/inputSchema.ts
@@ -39,11 +39,11 @@ export const InputSchema = z.object({
   password: z.string().min(1, "비밀번호를 입력해주세요").superRefine(validatePassword), // 비밀번호
   passwordConfirm: z.string().min(1, "비밀번호 확인이 필요합니다"), // 비밀번호 확인
 
-  photoCardName: z
+  name: z
     .string()
     .min(1, "포토카드 이름을 입력해주세요") // 빈 값 방지
     .max(30, "최대 30자 이내로 입력해주세요"), // 포토카드 이름
-  photoCardContent: contentSchema, // 포토카드 설명
+  description: contentSchema, // 포토카드 설명
   image: fileSchema, // 사진 url
   price: z
     .string()

--- a/src/store/useUserStore.ts
+++ b/src/store/useUserStore.ts
@@ -15,7 +15,7 @@ interface UserStore {
   userInfo: UserInfo | null;
   isAuthenticated: boolean; // 로그인 여부
   setUser: (user: UserInfo) => void;
-  logout: () => void;
+  logout: () => Promise<void>;
   // logout: (queryClient: QueryClient) => void;
 }
 
@@ -30,12 +30,22 @@ const useUserStore = create<UserStore>()(
       },
 
       logout: async () => {
-        set({ userInfo: null, isAuthenticated: false });
-        await logoutAction();
+        try {
+          // 먼저 상태 초기화
+          set({ userInfo: null, isAuthenticated: false });
+
+          // 서버 로그아웃 실행
+          await logoutAction();
+        } catch (error) {
+          console.error("로그아웃 중 오류 발생:", error);
+          // 오류 발생 시에도 상태는 초기화
+          // set({ userInfo: null, isAuthenticated: false });
+        }
       },
     }),
     {
       name: "user-storage", // storage name
+      skipHydration: true, // 서버 사이드 렌더링 시 하이드레이션 스킵
     }
   )
 );


### PR DESCRIPTION
## 📌 개요

- 포토카드 생성 로직 수정

## ✨ 주요 변경 사항

- 포토카드 생성 api 요청 axiosClient로 바꿨습니다. 어차피 서버액션 사용하는거 아니고, 클라이언트 쪽에서 fetch하는거라 
그냥 기존에 설정해둔 axiosClient사용하니 withCredectial로 쿠키 잘 보내집니다.
- 포토카드 생성 요청시 body에 키 이름이 백엔드에서 받는 이름과 달라서 요청이 계속 실패하고있었어요. input name 다 백엔드쪽에 맞춰서 수정했습니다.

- ++ 추가로 로그아웃시 랜박 요청 보내지던 부분 해결했습니다. 로그인 완료했는데도 로그인화면에 머무르는 문제는 아직 해결 못한상태입니다.
