### PR TITLE
ui: 알림카드와 프로필카드 하나만 열리도록 수정

### DIFF
--- a/src/components/gnb/Header.tsx
+++ b/src/components/gnb/Header.tsx
@@ -65,8 +65,14 @@ const Header = () => {
 
   const unRead = notifications?.some(item => !item.readAt); // 읽지 않은 알림이 있는지 확인
 
-  const handleProfileOpen = () => setIsProfileOpen(prev => !prev);
-  const handleNotificationOpen = () => setIsNotificationOpen(prev => !prev);
+  const handleProfileOpen = () => {
+    setIsProfileOpen(prev => !prev);
+    setIsNotificationOpen(false);
+  };
+  const handleNotificationOpen = () => {
+    setIsNotificationOpen(prev => !prev);
+    setIsProfileOpen(false);
+  };
   const handleLogout = async () => {
     try {
       await logout(); // XXX: 로그아웃 시 userStore가 초기화 되기 전에 로그아웃 알림 떠버려서 랜덤박스 요청 보내지던 이슈 해결


### PR DESCRIPTION
## 📌 개요

- ui: 알림카드와 프로필카드 하나만 열리도록 수정

## ✨ 주요 변경 사항

-

## 📢 공유 사항(다른 팀원들도 알아두어야 할 것들)

-

## 🔗 관련 이슈

-

## 🖼️ 스크린샷

![image](https://github.com/user-attachments/assets/9d68b148-7ea8-46f5-acd6-fe903aa49623)

