### PR TITLE
fix: 교환 제안 액션 후 알림 invalidate

### DIFF
--- a/src/hooks/market/detail/useExchangeCardActioinHook.tsx
+++ b/src/hooks/market/detail/useExchangeCardActioinHook.tsx
@@ -4,7 +4,7 @@ import {
   acceptExchangeOfferApi,
   declineExchangeOfferApi,
 } from "@/services/market/exchangeCardActionService";
-import { photoCardKeys } from "@/utils/queryKeys";
+import { photoCardKeys, userKeys } from "@/utils/queryKeys";
 
 // 판매카드 교환 제시 승인/거절/취소 핸들러 모음 훅
 export const useExchangeCardActionHook = () => {
@@ -21,6 +21,7 @@ export const useExchangeCardActionHook = () => {
       if (response) {
         // 교환 완료 후 캐시 무효화
         queryClient.invalidateQueries({ queryKey: photoCardKeys.all });
+        queryClient.invalidateQueries({ queryKey: userKeys.all });
 
         openSnackbar("SUCCESS", `교환이 성사되었습니다!`, "교환");
       }
@@ -41,6 +42,7 @@ export const useExchangeCardActionHook = () => {
       const response = await declineExchangeOfferApi(saleCardId);
       if (response) {
         queryClient.invalidateQueries({ queryKey: photoCardKeys.all });
+        queryClient.invalidateQueries({ queryKey: userKeys.all });
         openSnackbar("SUCCESS", "교환 제안을 거절했습니다.");
       }
     } catch (error) {
@@ -58,6 +60,7 @@ export const useExchangeCardActionHook = () => {
       const response = await declineExchangeOfferApi(saleCardId);
       if (response) {
         queryClient.invalidateQueries({ queryKey: photoCardKeys.all });
+        queryClient.invalidateQueries({ queryKey: userKeys.all });
         openSnackbar("SUCCESS", "교환 제안을 취소했습니다.");
       }
     } catch (error) {

--- a/src/hooks/market/detail/useExchangeOfferForm.tsx
+++ b/src/hooks/market/detail/useExchangeOfferForm.tsx
@@ -4,7 +4,7 @@ import { useCallback, useState } from "react";
 import { PostExchangeOfferBodyParams } from "@/types/photocard.types";
 import { useSnackbarStore } from "@/store/useSnackbarStore";
 import { postExchangeOfferApi } from "@/services/market/exchangeCardActionService";
-import { photoCardKeys } from "@/utils/queryKeys";
+import { photoCardKeys, userKeys } from "@/utils/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
 
 // 교환 제시 등록 훅
@@ -45,6 +45,9 @@ export const useExchangeOfferForm = () => {
         // 교환 제시 등록 시 교환 목록, 마이갤러리 무효화(그냥 전체 무효화로 처리)
         queryClient.invalidateQueries({
           queryKey: photoCardKeys.all,
+        });
+        queryClient.invalidateQueries({
+          queryKey: userKeys.all,
         });
         openSnackbar("SUCCESS", "포토카드 교환 제시에 성공했습니다!", "교환 제시");
         handleContentReset();


### PR DESCRIPTION
## 📌 개요

- 상세페이지에서 교환 승인/거절/취소 후에 알림 queryKey invalidate를 추가하여 바로 알림이 업데이트됩니다.
